### PR TITLE
Bugfix: Ensure that pycaches are not counted for the test graph.

### DIFF
--- a/tests/importer/test_parser.py
+++ b/tests/importer/test_parser.py
@@ -1,18 +1,19 @@
 from pathlib import Path
 
+from pytestarch.config.config import Config
+from pytestarch.importer.file_filter import FileFilter
 from pytestarch.importer.parser import Parser
-from util import MockFileFilter
 
 SOURCE_ROOT = Path(__file__).parent.parent
 RESOURCES_DIR = SOURCE_ROOT / "resources/importer"
 
 
 def test_parser_parses_all_files_in_directory() -> None:
-    parser = Parser(SOURCE_ROOT, MockFileFilter(), False)
+    parser = Parser(SOURCE_ROOT, FileFilter(Config(("*__pycache__",))), False)
 
     all_modules, parsed_modules = parser.parse(RESOURCES_DIR)
 
-    assert len(all_modules) == 25
+    assert len(all_modules) == 22
     assert len(parsed_modules) == 14
 
     expected_modules = {


### PR DESCRIPTION
The presence of these caches can differ between project setups and could cause tests to fail.