### PR TITLE
Bugfix: Internal modules no longer filtered out if root and module pa…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,8 @@ This project uses semantic versioning and follows [keep a changelog](https://kee
 
 
 ## [Unreleased]
+### Fixed
+- All internal modules filtered out if module and root path are not identical and are a sub module of the actual root module.
 
 ## [1.0.1] -- 2022-09-27
 ### Fixed

--- a/docs/parsing.md
+++ b/docs/parsing.md
@@ -6,6 +6,8 @@
 
 ## ::: src.pytestarch.importer.import_filter
 
+## ::: src.pytestarch.importer.import_path_padder
+
 ## ::: src.pytestarch.importer.import_types
 
 ## ::: src.pytestarch.importer.importee_module_calculator

--- a/src/pytestarch/importer/import_filter.py
+++ b/src/pytestarch/importer/import_filter.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import List
 
 from pytestarch.importer.import_types import Import
@@ -9,17 +8,15 @@ class ImportFilter:
     External modules are all modules that are not submodules of the configured module to search for imports.
     """
 
-    def __init__(
-        self, exclude_external_libraries: bool, root_module_path: Path
-    ) -> None:
+    def __init__(self, exclude_external_libraries: bool, root_module_name: str) -> None:
         """
         Args:
             exclude_external_libraries: If True, external modules will be filtered out, otherwise this class implements a no-op.
-            root_module_path: path to the module that determines which modules are considered external. If a module
+            root_module_name: name of the module that determines which modules are considered external. If a module
                 is a submodule of this module, it is considered internal.
         """
         self._exclude_external_libraries = exclude_external_libraries
-        self._root_module_path = root_module_path
+        self._root_module_name = root_module_name
 
     def filter(self, imports: List[Import]) -> List[Import]:
         """According to the configuration, imports will be filtered.
@@ -37,6 +34,4 @@ class ImportFilter:
     def _is_internal_import(self, i: Import) -> bool:
         importee = i.importee()
 
-        top_level_module = self._root_module_path.name
-
-        return importee.startswith(top_level_module)
+        return importee.startswith(self._root_module_name)

--- a/src/pytestarch/importer/import_path_padder.py
+++ b/src/pytestarch/importer/import_path_padder.py
@@ -1,0 +1,33 @@
+import os
+from pathlib import Path
+from typing import List
+
+from pytestarch.importer.import_types import Import
+
+
+class ImportPathPadder:
+    """Ensures that paths to imported internal modules match path structure of importing internal modules."""
+
+    @classmethod
+    def pad(cls, imports: List[Import], root_path: Path, module_path: Path) -> str:
+        """
+        Appends a prefix to all internal import module paths to ensure that importing and imported modules have the
+        same module prefix. This becomes necessary if the root and module path are not identical.
+
+        Args:
+            imports: list of Imports to update
+            root_path: Path to the root module
+            module_path: Path to the top level module to scan
+
+        Returns:
+            appended prefix based on the difference between root and module path
+        """
+        short_prefix = str(module_path.relative_to(root_path)).replace(os.sep, ".")
+        # drop name of module_path module itself, as this is already part of the import paths
+        full_prefix = ".".join(short_prefix.split(".")[:-1])
+
+        for imp in imports:
+            if not imp.importer().startswith(full_prefix):
+                imp.update_import_prefixes(full_prefix, module_path.name)
+
+        return full_prefix

--- a/src/pytestarch/pytestarch.py
+++ b/src/pytestarch/pytestarch.py
@@ -11,6 +11,7 @@ from pytestarch.config.config import Config
 from pytestarch.eval_structure.eval_structure_types import EvaluableArchitecture
 from pytestarch.eval_structure.evaluable_graph import EvaluableArchitectureGraph
 from pytestarch.eval_structure.graph import Graph
+from pytestarch.importer.import_path_padder import ImportPathPadder
 from pytestarch.importer.converter import ImportConverter
 from pytestarch.importer.file_filter import FileFilter
 from pytestarch.importer.import_filter import ImportFilter
@@ -31,7 +32,7 @@ def get_evaluable_architecture(
     """Constructs an evaluable object based on the given module.
 
     Args:
-        root_path: root directory of the source code
+        root_path: root directory of the source code. Should not be set to a submodule of the top level module.
         module_path: path of module to generate the evaluable for. Must be a submodule of the root_path module.
         exclusions: pseudo-regex to exclude files and directories from being integrated into the evaluable, e.g. *Test.py
         exclude_external_libraries: if True, external dependencies (defined as all dependencies to module outside the
@@ -60,7 +61,11 @@ def get_evaluable_architecture(
 
     imports = converter.convert(ast)
 
-    import_filter = ImportFilter(exclude_external_libraries, module_path)
+    full_prefix = ImportPathPadder.pad(imports, root_path, module_path)
+
+    import_filter = ImportFilter(
+        exclude_external_libraries, full_prefix + module_path.name
+    )
     imports = import_filter.filter(imports)
 
     if not exclude_external_libraries:

--- a/tests/importer/test_import_filter.py
+++ b/tests/importer/test_import_filter.py
@@ -12,7 +12,7 @@ imports = [
 
 
 def test_import_filter_excludes_external_dependencies() -> None:
-    filter = ImportFilter(True, ROOT_PATH)
+    filter = ImportFilter(True, str(ROOT_PATH))
     filtered_imports = filter.filter(imports)
 
     assert len(filtered_imports) == 1
@@ -20,7 +20,7 @@ def test_import_filter_excludes_external_dependencies() -> None:
 
 
 def test_import_filter_includes_internal_dependencies() -> None:
-    filter = ImportFilter(False, ROOT_PATH)
+    filter = ImportFilter(False, str(ROOT_PATH))
     filtered_imports = filter.filter(imports)
 
     assert len(filtered_imports) == 2

--- a/tests/resources/test_project/src/moduleA/submoduleA1/submoduleA11/fileA11.py
+++ b/tests/resources/test_project/src/moduleA/submoduleA1/submoduleA11/fileA11.py
@@ -1,4 +1,5 @@
 from src.moduleB.submoduleB1.fileB1 import b1  # type: ignore
+import os  # noqa: F401 E401
 
 
 def a11():


### PR DESCRIPTION
…th are identical and a submodule of the actual root module.

In this case, the importing modules need to have a prefix containing the difference in paths between root and module. Otherwise the importing modules will have paths starting with the base module; the imported modules will start with the root module. This means that no edges could be constructed.

Closes #28 