### PR TITLE
Feature: Add language support for "should not import anything" and "s…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,11 @@ This project uses semantic versioning and follows [keep a changelog](https://kee
 
 
 ## [Unreleased]
+## [1.2.1] -- 2022-10-08
+### Fixed
+- Line separator for rule violation messages
+
+
 ## [1.1.1] -- 2022-10-04
 ### Fixed
 - Line separator for rule violation messages

--- a/docs/details.md
+++ b/docs/details.md
@@ -136,7 +136,9 @@ Currently, the following markers are supported by PyTestArch:
 * are_submodules_of("Y"): applies to submodules of module named "Y", but not "Y" itself
 
 #### RULE_OBJECT
-same as RULE_SUBJECT
+same as RULE_SUBJECT, with an additional
+
+anything(): can only be used in combination with should_not()
 
 In addition, RULE_OBJECTS can be passed in as a list. The rule is fulfilled if it applies to all rule objects.
 For example, the rule
@@ -186,7 +188,7 @@ modules_that()
 
 Most rules are so close to the English language that a detailed explanation seems unnecessary. An exception might be the
 VERB_MARKER_2 "except". A combination of this VERB_MARKER_2 and every type of VERB_MARKER_1 and IMPORT_TYPE is given below
-as reference (M1, M2 are used as RULE_SUBJECT and RULE_OBJECT respectively; pseudo code for brevity):
+as reference (M1, M2 are used as RULE_SUBJECT and RULE_OBJECT respectively; pseudo-code for brevity):
 
 | Rule | Explanation |
 | ---- | ----------- |
@@ -195,7 +197,13 @@ as reference (M1, M2 are used as RULE_SUBJECT and RULE_OBJECT respectively; pseu
 | M1 should not import except M2| M1 should not import any module other than M2, but does not have to import M2 |
 | M1 should be imported except by M2 | at least one module that isn't M2 should import M1 (M2 can import M1 as well) |
 | M1 should only be imported except by M2 | at least one module that isn't M2 should import M1, and M2 cannot import M1 |
-| M1 should not be imported except by M2 | no module other than M2 should import M1, but M2 does not have to import M1
+| M1 should not be imported except by M2 | no module other than M2 should import M1, but M2 does not have to import M1 |
+
+
+There are two aliases to make rules easier:
+
+* 'M1 should not import anything' is equivalent to: 'M1 should not import anything except itself' (e.g. imports between its submodules are allowed, but no other imports)
+* 'M1 should not be imported by anything' is equivalent to: 'M1 should not be imported by anything except itself' (dito)
 
 
 ## Generating the evaluable architecture representation
@@ -226,4 +234,4 @@ a submodule of it.
 
 ### Module names
 In all rules, modules have to be referred to by their fully qualified name, meaning relative to the `root_path` - not the
-`module_path`! This helps distinguishing between internal and external modules.
+`module_path`! This helps to distinguish between internal and external modules.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyTestArch"
-version = "1.1.1"
+version = "1.2.0"
 description = "Test framework for software architecture based on imports between modules"
 authors = ["zyskarch <zyskarch@gmail.com>"]
 maintainers = ["zyskarch <zyskarch@gmail.com>"]

--- a/src/pytestarch/query_language/LANGUAGE_DEFINTION.md
+++ b/src/pytestarch/query_language/LANGUAGE_DEFINTION.md
@@ -18,6 +18,7 @@ IMPORT_TYPE:
 SUBJECT/OBJECT:
     sub_module_of
     name  # complete match
+    anything (only object)
 
 
 M1 should import_from M2
@@ -33,6 +34,21 @@ M1 should only be_imported_from M2
 M1 should only be_imported_from except M2  # M2 cannot import M1, but min other module is importing M1
 M1 should not be_imported_from M2
 M1 should not be_imported_from except M2  # M1 does not have to be imported
+
+
+not all combinations are possible with anything:
+M1 should import anything                       x
+M1 should import except anything                x
+M1 should only import anything                  x
+M1 should only import except anything           x
+M1 should not import anything                   o
+M1 should not import except anything            x
+M1 should be_imported by anything               x
+M1 should be_imported by except anything        x
+M1 should only be_imported by anything          x
+M1 should only be_imported except by anything   x
+M1 should not be_imported by anything           o
+M1 should not be_imported except by anything    x
 
 
 
@@ -52,9 +68,17 @@ M1 should be_imported_from except M2        -> any edge from non-M2 to M1
 M1 should only be_imported_from except M2   -> any edge from non-M2 to M1, neg(edge from M2 to M1)
 M1 should not be_imported_from except M2    -> neg(any edge from non-M2 to M1)
 
+M1 should not import anything               -> neg(any edge from M1 to ?)
+M1 should not be_imported by anything       -> neg(any edge from ? to M1)
+
 
 If M2 contains multiple modules, they can be treated separately for "edge", but need to be considered jointly for 
 "any edge".
+
+
+Aliases:
+M1 should not import anything -> M1 should not import anything except itself
+M1 should not be imported by anything -> M1 should not be imported by anything except itself
 
 
 
@@ -66,10 +90,10 @@ Operations:
 
 
 Operation Markers:
-    any         should import except, should only import except | should be except, should only be except
-    edge        should import, should only import               | should be, should only be
-    neg edge    should not import, should only import except    | should not be, should only be except
-    neg any     should not import except, should only import    | should only be, should not be except
+    any         should import except, should only import except             | should be except, should only be except
+    edge        should import, should only import                           | should be, should only be
+    neg edge    should not import, should only import except                | should not be, should only be except
+    neg any     should not import except, should only import                | should only be, should not be except
 
 simplified:
     any         should except, should only except

--- a/tests/query_language/test_base_language.py
+++ b/tests/query_language/test_base_language.py
@@ -1,11 +1,14 @@
 import pytest
 
-from pytestarch.eval_structure.evaluable_architecture import EvaluableArchitecture
+from pytestarch.eval_structure.evaluable_architecture import (
+    EvaluableArchitecture,
+    Module,
+)
 from pytestarch.eval_structure.evaluable_graph import EvaluableArchitectureGraph
 from pytestarch.eval_structure_impl.networkxgraph import NetworkxGraph
 from pytestarch.exceptions import ImproperlyConfigured
 from pytestarch.importer.import_types import AbsoluteImport
-from pytestarch.query_language.base_language import Rule
+from pytestarch.query_language.base_language import Rule, RuleConfiguration
 
 MODULE_1 = "Module1"
 MODULE_2 = "Module2"
@@ -17,6 +20,8 @@ SUB_MODULE_OF_7 = "Module7.SubModule1"
 MODULE_7 = "Module7"
 SUB_MODULE_OF_1 = "Module1.SubModule1"
 SUB_SUB_MODULE_OF_1 = "Module1.SubModule1.SubModule1"
+
+MODULE_A = Module(name="A")
 
 
 def test_rule_to_str_as_expected() -> None:
@@ -1306,3 +1311,130 @@ def test_should_not_be_imported_except_submodule_submodule_negative(
     )
 
     assert_not_rule_does_not_apply(rule, evaluable1)
+
+
+config_alias_test_cases = [
+    [
+        RuleConfiguration(
+            should_not=True,
+            import_=True,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=True,
+        ),
+        RuleConfiguration(
+            should_not=True,
+            import_=True,
+            except_present=True,
+            module_to_check=MODULE_A,
+            modules_to_check_against=[MODULE_A],
+            rule_object_anything=False,
+        ),
+    ],
+    [
+        RuleConfiguration(
+            should_not=True,
+            import_=False,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=True,
+        ),
+        RuleConfiguration(
+            should_not=True,
+            import_=False,
+            except_present=True,
+            module_to_check=MODULE_A,
+            modules_to_check_against=[MODULE_A],
+            rule_object_anything=False,
+        ),
+    ],
+    [
+        rule := RuleConfiguration(
+            should_not=True,
+            import_=True,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should_not=True,
+            import_=False,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should_not=True,
+            import_=True,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should_not=True,
+            import_=False,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should_only=True,
+            import_=True,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should_only=True,
+            import_=False,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should=True,
+            import_=True,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+    [
+        rule := RuleConfiguration(
+            should=True,
+            import_=False,
+            except_present=False,
+            module_to_check=MODULE_A,
+            rule_object_anything=False,
+        ),
+        rule,
+    ],
+]
+
+
+@pytest.mark.parametrize("config_with_alias, expected_config", config_alias_test_cases)
+def test_aliases_converted(
+    config_with_alias: RuleConfiguration,
+    expected_config: RuleConfiguration,
+) -> None:
+    converted_config = Rule._convert_aliases(config_with_alias)
+    assert converted_config == expected_config


### PR DESCRIPTION
…hould not be imported by anything".

These two rules are semantically equivalent to "should not import any module except itself" and "should not be imported by any module except itself". The "except itself" is needed to permit imports between submodules of the module.

Closes #43 