### PR TITLE
fix: use typing module for type annotations of generic types

### DIFF
--- a/src/pytestarch/diagram_import/diagram_parser.py
+++ b/src/pytestarch/diagram_import/diagram_parser.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional, Set, Tuple
 
 from pytestarch.diagram_import.parsed_dependencies import ParsedDependencies
 from pytestarch.exceptions import PumlParsingError
@@ -99,7 +99,7 @@ class PumlParser(DiagramParser):
     @classmethod
     def _retrieve_modules_declared_outside_dependencies(
         cls, content: str
-    ) -> set[Module]:
+    ) -> Set[Module]:
         module_group_1 = "m1"
         module_group_2 = "m2"
         alias_group = "alias"
@@ -133,7 +133,7 @@ class PumlParser(DiagramParser):
     def _retrieve_dependencies_and_inline_modules(
         cls,
         content: str,
-    ) -> dict[str, set[str]]:
+    ) -> Dict[str, Set[str]]:
         dependor_group_1 = "dependor1"
         dependor_group_2 = "dependor2"
 
@@ -166,9 +166,9 @@ class PumlParser(DiagramParser):
 
     def _unify(
         self,
-        modules: set[Module],
-        dependencies: dict[str, set[str]],
-    ) -> tuple[set[str], dict[str, set[str]]]:
+        modules: Set[Module],
+        dependencies: Dict[str, Set[str]],
+    ) -> Tuple[Set[str], Dict[str, Set[str]]]:
         unified_dependencies = {}
 
         all_aliases = self._get_modules_by_alias(modules)
@@ -188,9 +188,9 @@ class PumlParser(DiagramParser):
     @classmethod
     def _get_unified_modules(
         cls,
-        modules: set[Module],
-        unified_dependencies: dict[str, set[str]],
-    ) -> set[str]:
+        modules: Set[Module],
+        unified_dependencies: Dict[str, Set[str]],
+    ) -> Set[str]:
         all_modules = {m.name for m in modules}
 
         all_modules.update(set(unified_dependencies.keys()))
@@ -201,11 +201,11 @@ class PumlParser(DiagramParser):
         return all_modules
 
     @classmethod
-    def _get_modules_by_alias(cls, modules: set[Module]) -> dict[str, str]:
+    def _get_modules_by_alias(cls, modules: Set[Module]) -> Dict[str, str]:
         return {
             module.alias: module.name for module in modules if module.alias is not None
         }
 
     @classmethod
-    def _unify_module(cls, module: str, all_aliases: dict[str, str]) -> str:
+    def _unify_module(cls, module: str, all_aliases: Dict[str, str]) -> str:
         return all_aliases.get(module, module)

--- a/src/pytestarch/diagram_import/parsed_dependencies.py
+++ b/src/pytestarch/diagram_import/parsed_dependencies.py
@@ -1,7 +1,8 @@
 from dataclasses import dataclass
+from typing import Dict, Set
 
 
 @dataclass(frozen=True)
 class ParsedDependencies:
-    all_modules: set[str]
-    dependencies: dict[str, set[str]]
+    all_modules: Set[str]
+    dependencies: Dict[str, Set[str]]

--- a/src/pytestarch/eval_structure/evaluable_graph.py
+++ b/src/pytestarch/eval_structure/evaluable_graph.py
@@ -3,7 +3,7 @@ and edges to its subclasses in a template pattern.
 """
 from collections import defaultdict
 from itertools import product
-from typing import Any, List, Set, Union, Iterable
+from typing import Any, Dict, Iterable, List, Set, Tuple, Union
 
 from pytestarch.eval_structure.evaluable_architecture import (
     EvaluableArchitecture,
@@ -370,10 +370,10 @@ class EvaluableArchitectureGraph(EvaluableArchitecture):
 
     def _split_into_complete_modules_and_partial_matches(
         self,
-        modules_by_group: dict[int, List[Any]],
-    ) -> tuple[dict[int, List[AbstractNode]], dict[int, List[Module]]]:
-        result_by_group: dict[int, List[Module]] = defaultdict(list)
-        partial_match_module_name_by_group: dict[int, List[AbstractNode]] = {}
+        modules_by_group: Dict[int, List[Any]],
+    ) -> Tuple[Dict[int, List[AbstractNode]], Dict[int, List[Module]]]:
+        result_by_group: Dict[int, List[Module]] = defaultdict(list)
+        partial_match_module_name_by_group: Dict[int, List[AbstractNode]] = {}
 
         for group, modules in modules_by_group.items():
             partial_match_module_names = []
@@ -391,7 +391,7 @@ class EvaluableArchitectureGraph(EvaluableArchitecture):
 
     @classmethod
     def _convert_dict_values_to_list_sorted_by_keys(
-        cls, d: dict[Any, Iterable[Any]]
+        cls, d: Dict[Any, Iterable[Any]]
     ) -> List[List[Any]]:
         return [group_and_values[1] for group_and_values in sorted(d.items())]
 

--- a/src/pytestarch/eval_structure_impl/networkxgraph.py
+++ b/src/pytestarch/eval_structure_impl/networkxgraph.py
@@ -1,5 +1,6 @@
 """Encapsulation of networkx graph functionality."""
-from typing import Any, List, Optional, Tuple
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 import networkx as nx
 from networkx import draw_networkx, has_path, spring_layout
@@ -203,7 +204,7 @@ class NetworkxGraph(AbstractGraph):
 
         Keyword Args:
             spacing (float): optimal distance between nodes
-            aliases (dict[str, str]): module name aliases for plot labels. Keys are
+            aliases (Dict[str, str]): module name aliases for plot labels. Keys are
                 module names and values the aliases. If no alias is specified the module
                 name is used a node label. If a module name has an alias, the module
                 name is replaced by the alias for the module and all its submodules,
@@ -228,8 +229,8 @@ class NetworkxGraph(AbstractGraph):
 
         draw_networkx(self._graph, **kwargs)
 
-    def _create_plot_labels_with_alias(self, aliases: dict[str, str]) -> dict[str, str]:
-        module_names: list[str] = list(self._graph.nodes)
+    def _create_plot_labels_with_alias(self, aliases: Dict[str, str]) -> Dict[str, str]:
+        module_names: List[str] = list(self._graph.nodes)
         self._assert_aliased_modules_exist(aliases, module_names)
 
         # longest name first so aliases for submodule take priority over aliases  for
@@ -248,8 +249,8 @@ class NetworkxGraph(AbstractGraph):
 
     def _assert_aliased_modules_exist(
         self,
-        aliases: dict[str, str],
-        module_names: list[str],
+        aliases: Dict[str, str],
+        module_names: List[str],
     ) -> None:
         for module in aliases:
             if module not in module_names:
@@ -261,8 +262,8 @@ class NetworkxGraph(AbstractGraph):
     def _create_label(
         self,
         module_name: str,
-        sorted_aliased_modules: list[str],
-        aliases: dict[str, str],
+        sorted_aliased_modules: List[str],
+        aliases: Dict[str, str],
     ) -> str:
         try:
             most_specific_aliased_module = next(
@@ -270,7 +271,7 @@ class NetworkxGraph(AbstractGraph):
                 for module in sorted_aliased_modules
                 if module_name.startswith(module)
             )
-            alias = module_name.removeprefix(most_specific_aliased_module)
+            alias = re.sub(rf"^{most_specific_aliased_module}", "", module_name)
             alias = aliases[most_specific_aliased_module] + alias
             return alias
 

--- a/src/pytestarch/query_language/diagrams/dependency_to_rule_converter.py
+++ b/src/pytestarch/query_language/diagrams/dependency_to_rule_converter.py
@@ -1,3 +1,5 @@
+from typing import List, Set
+
 from pytestarch import Rule
 from pytestarch.diagram_import.parsed_dependencies import ParsedDependencies
 from pytestarch.query_language.base_language import RuleApplier
@@ -7,7 +9,7 @@ class DependencyToRuleConverter:
     def __init__(self, should_only_rule: bool) -> None:
         self._should_only_rule = should_only_rule
 
-    def convert(self, dependencies: ParsedDependencies) -> list[RuleApplier]:
+    def convert(self, dependencies: ParsedDependencies) -> List[RuleApplier]:
         """Converts a parsed dependency object to a list of RuleAppliers.
         All explicit dependencies in the given object are converted to should (only) rules.
         All missing, but possible dependencies between the given modules are converted to 'should not' rules.
@@ -23,13 +25,13 @@ class DependencyToRuleConverter:
 
     def _convert_should_rules(
         self, dependencies: ParsedDependencies
-    ) -> list[RuleApplier]:
+    ) -> List[RuleApplier]:
         return [
             self._generate_rule(importer, importees)
             for importer, importees in dependencies.dependencies.items()
         ]
 
-    def _generate_rule(self, importer: str, importees: set[str]) -> RuleApplier:
+    def _generate_rule(self, importer: str, importees: Set[str]) -> RuleApplier:
         rule_subject = Rule().modules_that().are_named(importer)
 
         if self._should_only_rule:
@@ -42,7 +44,7 @@ class DependencyToRuleConverter:
     @classmethod
     def _convert_should_not_rules(
         cls, parsed_dependencies: ParsedDependencies
-    ) -> list[RuleApplier]:
+    ) -> List[RuleApplier]:
         # sorting in this method is necessary to generate a reliable order of returned rules
         # this helps with testing and overall consistency
         rules = []

--- a/src/pytestarch/query_language/diagrams/diagram_rule.py
+++ b/src/pytestarch/query_language/diagrams/diagram_rule.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.diagram_import.diagram_parser import PumlParser
@@ -92,11 +92,11 @@ class DiagramRule(FileRule, BaseModuleSpecifier, RuleApplier):
     ) -> ParsedDependencies:
         return ModulePrefixer.prefix(parsed_dependencies, self._name_relative_to_root)
 
-    def _convert_to_rules(self, dependencies: ParsedDependencies) -> list[RuleApplier]:
+    def _convert_to_rules(self, dependencies: ParsedDependencies) -> List[RuleApplier]:
         return DependencyToRuleConverter(self._should_only_rule).convert(dependencies)
 
     @classmethod
     def _apply_rules(
-        cls, rule_appliers: list[RuleApplier], evaluable: EvaluableArchitecture
+        cls, rule_appliers: List[RuleApplier], evaluable: EvaluableArchitecture
     ) -> None:
         MultipleRuleApplier(rule_appliers).assert_applies(evaluable)

--- a/src/pytestarch/query_language/multiple_rule_applier.py
+++ b/src/pytestarch/query_language/multiple_rule_applier.py
@@ -1,9 +1,11 @@
+from typing import List
+
 from pytestarch import EvaluableArchitecture
 from pytestarch.query_language.base_language import RuleApplier
 
 
 class MultipleRuleApplier(RuleApplier):
-    def __init__(self, rule_appliers: list[RuleApplier]) -> None:
+    def __init__(self, rule_appliers: List[RuleApplier]) -> None:
         self._rule_appliers = rule_appliers
 
     def assert_applies(self, evaluable: EvaluableArchitecture) -> None:


### PR DESCRIPTION
[PEP 585](https://peps.python.org/pep-0585/) is not supported by Python < 3.9. This is why i changed all type hints in that way that  they are using the `typing` module.

Closes: #53 