### PR TITLE
Fix typing

### DIFF
--- a/src/pytestarch/query_language/base_language.py
+++ b/src/pytestarch/query_language/base_language.py
@@ -79,7 +79,7 @@ class BehaviorSpecification(BehaviorBaseSpecification["DependencySpecification"]
 
 
 ModuleSpecificationSuccessor = TypeVar(
-    "ModuleSpecificationSuccessor", BehaviorBaseSpecification, RuleApplier
+    "ModuleSpecificationSuccessor", BehaviorSpecification, RuleApplier
 )
 
 


### PR DESCRIPTION
Hi @zyskarch

I've noticed, that your library had problems with various static analysis tools, like `mypy` or `pyright`.

**First problem**: `pyright` doesn't support any code completion, and `mypy` doesn't analyze anything.

```bash
$ mypy .
tests/test_arch.py:1: error: Skipping analyzing "pytestarch": module is installed, but missing library stubs or py.typed marker  [import-untyped]
```

Reason is, that the library - even though it is typed - doesn't tell those tools that it supports type checking.
Adding an empty file called `py.typed` is enough.
(More infos: https://peps.python.org/pep-0561/#packaging-type-information)

**Second problem**: the `pyright` language server get's confused and can't figure out what comes after the behavior step. And therefore doesn't support any autocomplete features any more.

![image](https://github.com/zyskarch/pytestarch/assets/7143573/359cebd5-a660-4f91-bc72-6f0b5aea0e2e)

![image](https://github.com/zyskarch/pytestarch/assets/7143573/7b9fd254-3361-41a0-bc1c-6b8b5a125bc6)

![image](https://github.com/zyskarch/pytestarch/assets/7143573/44047779-0926-4cde-b4f3-2f7d091b14a8)


The problem is, that one of the type vars was specified via the generic class `BehaviorBaseSpecification`, which is kinda wrong as the syntax `TypeVar("Name", Foo, Bar)` says that the type is exactly either `Foo` or `Bar`, but not some concrete class that's derived/inherited from a generic `Foo`.