### PR TITLE
Documentation: Root module path needs to be included in module names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ from pytestarch import Rule
 rule = (
     Rule() 
     .modules_that() 
-    .are_named("src.moduleB") 
+    .are_named("project.src.moduleB") 
     .should_not() 
     .be_imported_by_modules_that() 
-    .are_sub_modules_of("src.moduleA") 
+    .are_sub_modules_of("project.src.moduleA") 
 )
 ```
 
-This rule represents the architectural requirements that a module named "src.moduleB" should not be imported by any module
-that is a submodule of "src.moduleA", excluding "src.moduleA" itself.
+This rule represents the architectural requirements that a module named "project.src.moduleB" should not be imported by any module
+that is a submodule of "project.src.moduleA", excluding "project.src.moduleA" itself.
 
 3) Evaluate your code against this rule
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,11 @@
 
 This project uses semantic versioning and follows [keep a changelog](https://keepachangelog.com).
 
+## [2.0.1] -- 2024-03-14
+### Fixed
+- Readme description on module name references.
+
+
 ## [2.0.0] -- 2024-02-23
 ### Changed
 - Matplotlib is no longer installed by default, as it is not required for the core functionality.

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,15 +30,15 @@ from pytestarch import Rule
 rule = (
     Rule()
     .modules_that() 
-    .are_named("src.moduleB") 
+    .are_named("project.src.moduleB") 
     .should_not() 
     .be_imported_by_modules_that() 
-    .are_sub_modules_of("src.moduleA")
+    .are_sub_modules_of("project.src.moduleA")
 )
 ```
 
-This rule represents the architectural requirements that a module named "src.moduleB" should not be imported by any module
-that is a submodule of "src.moduleA", excluding "src.moduleA" itself.
+This rule represents the architectural requirements that a module named "project.src.moduleB" should not be imported by any module
+that is a submodule of "project.src.moduleA", excluding "project.src.moduleA" itself.
 
 3) Evaluate your code against this rule
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "PyTestArch"
-version = "2.0.0"
+version = "2.0.1"
 description = "Test framework for software architecture based on imports between modules"
 authors = ["zyskarch <zyskarch@gmail.com>"]
 maintainers = ["zyskarch <zyskarch@gmail.com>"]


### PR DESCRIPTION
This has been documented previously as a caveat, but has not made its way into the readme.