### PR TITLE
Refactor: Update type annotations for python>=3.9

### DIFF
--- a/src/pytestarch/diagram_extension/dependency_to_rule_converter.py
+++ b/src/pytestarch/diagram_extension/dependency_to_rule_converter.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Set
-
 from pytestarch import Rule
 from pytestarch.diagram_extension.parsed_dependencies import ParsedDependencies
 from pytestarch.query_language.base_language import RuleApplier
@@ -11,7 +9,7 @@ class DependencyToRuleConverter:
     def __init__(self, should_only_rule: bool) -> None:
         self._should_only_rule = should_only_rule
 
-    def convert(self, dependencies: ParsedDependencies) -> List[RuleApplier]:
+    def convert(self, dependencies: ParsedDependencies) -> list[RuleApplier]:
         """Converts a parsed dependency object to a list of RuleAppliers.
         All explicit dependencies in the given object are converted to should (only) rules.
         All missing, but possible dependencies between the given modules are converted to 'should not' rules.
@@ -27,13 +25,13 @@ class DependencyToRuleConverter:
 
     def _convert_should_rules(
         self, dependencies: ParsedDependencies
-    ) -> List[RuleApplier]:
+    ) -> list[RuleApplier]:
         return [
             self._generate_rule(importer, importees)
             for importer, importees in dependencies.dependencies.items()
         ]
 
-    def _generate_rule(self, importer: str, importees: Set[str]) -> RuleApplier:
+    def _generate_rule(self, importer: str, importees: set[str]) -> RuleApplier:
         rule_subject = Rule().modules_that().are_named(importer)
 
         if self._should_only_rule:
@@ -46,7 +44,7 @@ class DependencyToRuleConverter:
     @classmethod
     def _convert_should_not_rules(
         cls, parsed_dependencies: ParsedDependencies
-    ) -> List[RuleApplier]:
+    ) -> list[RuleApplier]:
         # sorting in this method is necessary to generate a reliable order of returned rules
         # this helps with testing and overall consistency
         rules = []

--- a/src/pytestarch/diagram_extension/diagram_parser.py
+++ b/src/pytestarch/diagram_extension/diagram_parser.py
@@ -5,7 +5,6 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Optional, Set, Tuple
 
 from pytestarch.diagram_extension.exceptions import PumlParsingError
 from pytestarch.diagram_extension.parsed_dependencies import ParsedDependencies
@@ -20,7 +19,7 @@ class DiagramParser(ABC):
 @dataclass(frozen=True)
 class Module:
     name: str
-    alias: Optional[str] = None
+    alias: str | None = None
 
 
 PUML_START_MARKER = "@startuml"
@@ -101,7 +100,7 @@ class PumlParser(DiagramParser):
     @classmethod
     def _retrieve_modules_declared_outside_dependencies(
         cls, content: str
-    ) -> Set[Module]:
+    ) -> set[Module]:
         module_group_1 = "m1"
         module_group_2 = "m2"
         alias_group = "alias"
@@ -135,7 +134,7 @@ class PumlParser(DiagramParser):
     def _retrieve_dependencies_and_inline_modules(
         cls,
         content: str,
-    ) -> Dict[str, Set[str]]:
+    ) -> dict[str, set[str]]:
         dependor_group_1 = "dependor1"
         dependor_group_2 = "dependor2"
 
@@ -168,9 +167,9 @@ class PumlParser(DiagramParser):
 
     def _unify(
         self,
-        modules: Set[Module],
-        dependencies: Dict[str, Set[str]],
-    ) -> Tuple[Set[str], Dict[str, Set[str]]]:
+        modules: set[Module],
+        dependencies: dict[str, set[str]],
+    ) -> tuple[set[str], dict[str, set[str]]]:
         unified_dependencies = {}
 
         all_aliases = self._get_modules_by_alias(modules)
@@ -190,9 +189,9 @@ class PumlParser(DiagramParser):
     @classmethod
     def _get_unified_modules(
         cls,
-        modules: Set[Module],
-        unified_dependencies: Dict[str, Set[str]],
-    ) -> Set[str]:
+        modules: set[Module],
+        unified_dependencies: dict[str, set[str]],
+    ) -> set[str]:
         all_modules = {m.name for m in modules}
 
         all_modules.update(set(unified_dependencies.keys()))
@@ -203,11 +202,11 @@ class PumlParser(DiagramParser):
         return all_modules
 
     @classmethod
-    def _get_modules_by_alias(cls, modules: Set[Module]) -> Dict[str, str]:
+    def _get_modules_by_alias(cls, modules: set[Module]) -> dict[str, str]:
         return {
             module.alias: module.name for module in modules if module.alias is not None
         }
 
     @classmethod
-    def _unify_module(cls, module: str, all_aliases: Dict[str, str]) -> str:
+    def _unify_module(cls, module: str, all_aliases: dict[str, str]) -> str:
         return all_aliases.get(module, module)

--- a/src/pytestarch/diagram_extension/diagram_rule.py
+++ b/src/pytestarch/diagram_extension/diagram_rule.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Optional
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.diagram_extension.dependency_to_rule_converter import (
@@ -21,7 +20,7 @@ from pytestarch.query_language.multiple_rule_applier import MultipleRuleApplier
 class ModulePrefixer:
     @classmethod
     def prefix(
-        cls, parsed_dependencies: ParsedDependencies, prefix: Optional[str]
+        cls, parsed_dependencies: ParsedDependencies, prefix: str | None
     ) -> ParsedDependencies:
         modules = parsed_dependencies.all_modules
         dependencies = parsed_dependencies.dependencies
@@ -37,7 +36,7 @@ class ModulePrefixer:
         )
 
     @classmethod
-    def _add_prefix_to_module(cls, module_name: str, prefix: Optional[str]) -> str:
+    def _add_prefix_to_module(cls, module_name: str, prefix: str | None) -> str:
         if prefix is None:
             return module_name
 
@@ -59,8 +58,8 @@ class DiagramRule(FileRule, BaseModuleSpecifier, RuleApplier):
              should_only_rule: if True, edges between components will be converted into 'should only import' rules.
              If False, 'should import' rules will be generated instead.
         """
-        self._file_path: Optional[Path] = None
-        self._name_relative_to_root: Optional[str] = None
+        self._file_path: Path | None = None
+        self._name_relative_to_root: str | None = None
         self._should_only_rule = should_only_rule
 
     def from_file(self, file_path: Path) -> BaseModuleSpecifier:
@@ -94,11 +93,11 @@ class DiagramRule(FileRule, BaseModuleSpecifier, RuleApplier):
     ) -> ParsedDependencies:
         return ModulePrefixer.prefix(parsed_dependencies, self._name_relative_to_root)
 
-    def _convert_to_rules(self, dependencies: ParsedDependencies) -> List[RuleApplier]:
+    def _convert_to_rules(self, dependencies: ParsedDependencies) -> list[RuleApplier]:
         return DependencyToRuleConverter(self._should_only_rule).convert(dependencies)
 
     @classmethod
     def _apply_rules(
-        cls, rule_appliers: List[RuleApplier], evaluable: EvaluableArchitecture
+        cls, rule_appliers: list[RuleApplier], evaluable: EvaluableArchitecture
     ) -> None:
         MultipleRuleApplier(rule_appliers).assert_applies(evaluable)

--- a/src/pytestarch/diagram_extension/parsed_dependencies.py
+++ b/src/pytestarch/diagram_extension/parsed_dependencies.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Set
 
 
 @dataclass(frozen=True)
 class ParsedDependencies:
-    all_modules: Set[str]
-    dependencies: Dict[str, Set[str]]
+    all_modules: set[str]
+    dependencies: dict[str, set[str]]

--- a/src/pytestarch/eval_structure/breadth_first_searches.py
+++ b/src/pytestarch/eval_structure/breadth_first_searches.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List, Set
-
 from pytestarch.eval_structure.evaluable_architecture import Dependency, ModuleFilter
 from pytestarch.eval_structure.evaluable_structures import AbstractGraph, AbstractNode
 from pytestarch.eval_structure.utils import get_node, get_parent_nodes, to_modules
@@ -9,7 +7,7 @@ from pytestarch.eval_structure.utils import get_node, get_parent_nodes, to_modul
 
 def get_dependency_between_modules(
     graph: AbstractGraph, dependent: ModuleFilter, dependent_upon: ModuleFilter
-) -> List[Dependency]:
+) -> list[Dependency]:
     dependent_node = get_node(dependent)
     dependent_upon_nodes = get_all_submodules_of(graph, dependent_upon)
 
@@ -44,8 +42,8 @@ def get_dependency_between_modules(
 
 
 def any_dependency_to_module_other_than(  # noqa: C901
-    graph: AbstractGraph, dependent: ModuleFilter, dependent_upons: Set[ModuleFilter]
-) -> List[Dependency]:
+    graph: AbstractGraph, dependent: ModuleFilter, dependent_upons: set[ModuleFilter]
+) -> list[Dependency]:
     # nodes to exclude are nodes that once reached will not have their submodules analysed next
     nodes_to_exclude = set()
     for dependent_upon in dependent_upons:
@@ -109,8 +107,8 @@ def any_dependency_to_module_other_than(  # noqa: C901
 
 
 def any_other_dependency_to_module_than(  # noqa: C901
-    graph: AbstractGraph, dependents: Set[ModuleFilter], dependent_upon: ModuleFilter
-) -> List[Dependency]:
+    graph: AbstractGraph, dependents: set[ModuleFilter], dependent_upon: ModuleFilter
+) -> list[Dependency]:
     # submodules of the dependent upon module do not count as an import that is not the dependent upon module
     # submodules of and including the dependent do not count as allowed imports
 
@@ -177,7 +175,7 @@ def any_other_dependency_to_module_than(  # noqa: C901
 
 def get_all_submodules_of(
     graph: AbstractGraph, module: ModuleFilter
-) -> Set[AbstractNode]:
+) -> set[AbstractNode]:
     """Returns all submodules of a given module.
 
     Args:

--- a/src/pytestarch/eval_structure/evaluable_architecture.py
+++ b/src/pytestarch/eval_structure/evaluable_architecture.py
@@ -4,19 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from bisect import bisect
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import (
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Mapping,
-    Optional,
-    Protocol,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import Any, Protocol
 
 from pytestarch.eval_structure.exceptions import LayerMismatch
 
@@ -28,11 +18,11 @@ class LayerMapping:
     def __init__(
         self,
         layer_mapping_for_module_filters: Mapping[
-            Layer, Union[Sequence[ModuleFilter], Sequence[Module]]
+            Layer, Sequence[ModuleFilter] | Sequence[Module]
         ],
     ) -> None:
         self._layer_mapping_for_module_filters = layer_mapping_for_module_filters
-        self._module_filter_mapping: Mapping[Union[ModuleFilter, Module], Layer] = {
+        self._module_filter_mapping: Mapping[ModuleFilter | Module, Layer] = {
             module: layer
             for layer, modules in layer_mapping_for_module_filters.items()
             for module in modules
@@ -54,7 +44,7 @@ class LayerMapping:
             if key.identifier == module.identifier
         ][0]
 
-    def _get_layer_or_none(self, module_name: str) -> Optional[Layer]:
+    def _get_layer_or_none(self, module_name: str) -> Layer | None:
         layers = [
             self._module_filter_mapping[key]
             for key in self._module_filter_mapping
@@ -66,7 +56,7 @@ class LayerMapping:
 
         return None
 
-    def get_layer_for_module_name(self, module_name: str) -> Optional[Layer]:
+    def get_layer_for_module_name(self, module_name: str) -> Layer | None:
         """Attempts to find the layer the given module belongs to. If the module does not appear in the
         layer definition itself, it is checked whether the module is a submodule of one of the modules in the layer
         definition. If so, the layer of the parent module is returned. Otherwise, None is returned.
@@ -219,14 +209,14 @@ class ModuleGroup(Module):
         return False
 
 
-Dependency = Tuple[Module, Module]
+Dependency = tuple[Module, Module]
 # key: user-requested dependency
 # values: list of exact modules that show this dependency
-ExplicitlyRequestedDependenciesByBaseModules = Dict[Dependency, List[Dependency]]
+ExplicitlyRequestedDependenciesByBaseModules = dict[Dependency, list[Dependency]]
 # key: module that either has dependencies or that others are dependent on that were not explicitly requested
 # via the rule the user has specified
 # value: importer and importee that were not found
-NotExplicitlyRequestedDependenciesByBaseModule = Dict[Module, List[Dependency]]
+NotExplicitlyRequestedDependenciesByBaseModule = dict[Module, list[Dependency]]
 
 
 class EvaluableArchitecture(Protocol):
@@ -311,6 +301,6 @@ class EvaluableArchitecture(Protocol):
         raise NotImplementedError()
 
     @property
-    def modules(self) -> List[str]:
+    def modules(self) -> list[str]:
         """Return names of all modules that are present in this architecture."""
         raise NotImplementedError()

--- a/src/pytestarch/eval_structure/evaluable_graph.py
+++ b/src/pytestarch/eval_structure/evaluable_graph.py
@@ -4,8 +4,9 @@ and edges to its subclasses in a template pattern.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Sequence
 from itertools import product
-from typing import Any, Iterable, List, Sequence
+from typing import Any
 
 from pytestarch.eval_structure.breadth_first_searches import (
     any_dependency_to_module_other_than,
@@ -91,5 +92,5 @@ class EvaluableArchitectureGraph(EvaluableArchitecture):
         self._graph.draw(**kwargs)  # type: ignore
 
     @property
-    def modules(self) -> List[str]:
+    def modules(self) -> list[str]:
         return self._graph.nodes

--- a/src/pytestarch/eval_structure/evaluable_structures.py
+++ b/src/pytestarch/eval_structure/evaluable_structures.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
 
 AbstractNode = str
 
 
 class AbstractGraph(ABC):
     @abstractmethod
-    def direct_successor_nodes(self, node: AbstractNode) -> List[AbstractNode]:
+    def direct_successor_nodes(self, node: AbstractNode) -> list[AbstractNode]:
         raise NotImplementedError()
 
     @abstractmethod
@@ -18,10 +17,10 @@ class AbstractGraph(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def direct_predecessor_nodes(self, node: AbstractNode) -> List[AbstractNode]:
+    def direct_predecessor_nodes(self, node: AbstractNode) -> list[AbstractNode]:
         raise NotImplementedError()
 
     @property
     @abstractmethod
-    def nodes(self) -> List[AbstractNode]:
+    def nodes(self) -> list[AbstractNode]:
         raise NotImplementedError()

--- a/src/pytestarch/eval_structure/module_name_converter.py
+++ b/src/pytestarch/eval_structure/module_name_converter.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
-from typing import Dict, List, Sequence, Tuple, cast
+from collections.abc import Sequence
+from typing import cast
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure.breadth_first_searches import get_all_submodules_of
@@ -22,7 +23,7 @@ class ModuleNameConverter:
     @classmethod
     def convert(
         cls, modules: Sequence[ModuleFilter], arch: EvaluableArchitecture
-    ) -> Tuple[Sequence[ModuleFilter], Dict[str, List[Module]]]:
+    ) -> tuple[Sequence[ModuleFilter], dict[str, list[Module]]]:
         """Converts each regex pattern that serves to identify module names into actual modules that match this pattern.
 
         Args:
@@ -88,8 +89,8 @@ class ModuleNameConverter:
     @classmethod
     def _split_modules_by_presence_of_regex_pattern(
         cls, modules: Sequence[ModuleFilter]
-    ) -> Tuple[List[ModuleNameRegexFilter], Sequence[ModuleFilter]]:
-        modules_with_regex_name_pattern: List[ModuleNameRegexFilter] = []
+    ) -> tuple[list[ModuleNameRegexFilter], Sequence[ModuleFilter]]:
+        modules_with_regex_name_pattern: list[ModuleNameRegexFilter] = []
         other_modules = []
 
         for module in modules:

--- a/src/pytestarch/eval_structure/networkxgraph.py
+++ b/src/pytestarch/eval_structure/networkxgraph.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Any
 
 import networkx as nx
 from networkx import draw_networkx, has_path, spring_layout
@@ -33,9 +34,9 @@ class NetworkxGraph(AbstractGraph):
 
     def __init__(
         self,
-        all_modules: List[Node],
+        all_modules: list[Node],
         imports: Sequence[Import],
-        level_limit: Optional[int] = None,
+        level_limit: int | None = None,
     ) -> None:
         """
         Args:
@@ -85,7 +86,7 @@ class NetworkxGraph(AbstractGraph):
 
     def _add_edges_within_module_hierarchy(
         self,
-        parent_modules: List[Node],
+        parent_modules: list[Node],
         child: Node,
     ) -> None:
         """Create edges between a node and its parent recursively until the parent-less parent is reached.
@@ -163,14 +164,14 @@ class NetworkxGraph(AbstractGraph):
         return self._graph.number_of_nodes()
 
     @property
-    def nodes(self) -> List[Node]:
+    def nodes(self) -> list[Node]:
         return list(self._graph.nodes)
 
     @property
-    def edges(self) -> List[Tuple[Node, Node]]:
+    def edges(self) -> list[tuple[Node, Node]]:
         return list(self._graph.edges)
 
-    def direct_predecessor_nodes(self, node: Node) -> List[Node]:
+    def direct_predecessor_nodes(self, node: Node) -> list[Node]:
         """Returns all nodes that have a directed edge towards the given node.
 
         Args:
@@ -181,7 +182,7 @@ class NetworkxGraph(AbstractGraph):
         """
         return sorted(self._graph.predecessors(node))
 
-    def direct_successor_nodes(self, node: Node) -> List[Node]:
+    def direct_successor_nodes(self, node: Node) -> list[Node]:
         """Returns all nodes that the given node has a directed edge towards.
 
         Args:
@@ -245,8 +246,8 @@ class NetworkxGraph(AbstractGraph):
 
         draw_networkx(self._graph, **kwargs)
 
-    def _create_plot_labels_with_alias(self, aliases: Dict[str, str]) -> Dict[str, str]:
-        module_names: List[str] = list(self._graph.nodes)
+    def _create_plot_labels_with_alias(self, aliases: dict[str, str]) -> dict[str, str]:
+        module_names: list[str] = list(self._graph.nodes)
         self._assert_aliased_modules_exist(aliases, module_names)
 
         # longest name first so aliases for submodule take priority over aliases  for
@@ -265,8 +266,8 @@ class NetworkxGraph(AbstractGraph):
 
     def _assert_aliased_modules_exist(
         self,
-        aliases: Dict[str, str],
-        module_names: List[str],
+        aliases: dict[str, str],
+        module_names: list[str],
     ) -> None:
         for module in aliases:
             if module not in module_names:
@@ -278,8 +279,8 @@ class NetworkxGraph(AbstractGraph):
     def _create_label(
         self,
         module_name: str,
-        sorted_aliased_modules: List[str],
-        aliases: Dict[str, str],
+        sorted_aliased_modules: list[str],
+        aliases: dict[str, str],
     ) -> str:
         try:
             most_specific_aliased_module = next(

--- a/src/pytestarch/eval_structure/types.py
+++ b/src/pytestarch/eval_structure/types.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
 
 
 class Import(ABC):
@@ -18,7 +17,7 @@ class Import(ABC):
         """
         return self._importer
 
-    def importer_parent_modules(self) -> List[str]:
+    def importer_parent_modules(self) -> list[str]:
         """Returns names of all parent modules of the importing module.
 
         Returns:
@@ -36,7 +35,7 @@ class Import(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def importee_parent_modules(self) -> List[str]:
+    def importee_parent_modules(self) -> list[str]:
         """Returns names of all parent modules of the imported module.
 
         Returns:
@@ -51,7 +50,7 @@ class Import(ABC):
         return f"{prefix}.{value}"
 
 
-def get_parent_modules(module: str) -> List[str]:
+def get_parent_modules(module: str) -> list[str]:
     """Calculates all parent modules of a given module.
 
     Example: source root is a
@@ -66,7 +65,7 @@ def get_parent_modules(module: str) -> List[str]:
     """
     parent_modules = []
 
-    parent: List[str] = []
+    parent: list[str] = []
 
     for char in module:
         if char == ".":

--- a/src/pytestarch/eval_structure/utils.py
+++ b/src/pytestarch/eval_structure/utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Sequence
+from collections.abc import Sequence
 
 from pytestarch.eval_structure.evaluable_architecture import (
     Module,
@@ -10,7 +10,7 @@ from pytestarch.eval_structure.evaluable_architecture import (
 from pytestarch.eval_structure.evaluable_structures import AbstractNode
 
 
-def to_modules(nodes: List[AbstractNode]) -> List[Module]:
+def to_modules(nodes: list[AbstractNode]) -> list[Module]:
     return list(map(lambda node: Module(identifier=node), nodes))
 
 
@@ -25,7 +25,7 @@ def get_node(module_filter: ModuleFilter) -> AbstractNode:
     return module_filter.identifier
 
 
-def get_parent_nodes(module_filters: Sequence[ModuleFilter]) -> List[AbstractNode]:
+def get_parent_nodes(module_filters: Sequence[ModuleFilter]) -> list[AbstractNode]:
     result = [
         module_filter.identifier
         for module_filter in module_filters

--- a/src/pytestarch/eval_structure_generation/file_import/config.py
+++ b/src/pytestarch/eval_structure_generation/file_import/config.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Tuple
 
 
 @dataclass
@@ -13,4 +12,4 @@ class Config:
         e.g. test directories.
     """
 
-    excluded_directories: Tuple[str, ...]
+    excluded_directories: tuple[str, ...]

--- a/src/pytestarch/eval_structure_generation/file_import/converter.py
+++ b/src/pytestarch/eval_structure_generation/file_import/converter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import ast
-from typing import List, Optional, Sequence, Set
+from collections.abc import Sequence
 
 from pytestarch.eval_structure.types import Import
 from pytestarch.eval_structure_generation.file_import.import_types import (
@@ -16,9 +16,9 @@ class ImportConverter:
 
     def convert(
         self,
-        asts: List[NamedModule],
+        asts: list[NamedModule],
         absolute_import_prefix: str,
-        internal_modules: Set[str],
+        internal_modules: set[str],
     ) -> Sequence[Import]:
         """Converts ast modules to custom import modules. Filters out all modules
         that are not imports.
@@ -31,7 +31,7 @@ class ImportConverter:
             list of import objects
         """
         module_to_search = asts
-        imports: List[Import] = []
+        imports: list[Import] = []
 
         while module_to_search:
             module = module_to_search.pop()
@@ -60,8 +60,8 @@ class ImportConverter:
         module: ast.Module,
         module_name: str,
         absolute_import_prefix: str,
-        all_internal_modules: Set[str],
-    ) -> Optional[Sequence[Import]]:
+        all_internal_modules: set[str],
+    ) -> Sequence[Import] | None:
         """Calculates all imports of the given ast module.
 
         Args:
@@ -73,7 +73,7 @@ class ImportConverter:
         Returns:
             list of calculated import objects
         """
-        new_imports: Optional[Sequence[Import]] = None
+        new_imports: Sequence[Import] | None = None
 
         if isinstance(module, ast.Import):
             new_imports = []
@@ -98,7 +98,7 @@ class ImportConverter:
         cls,
         module_name: str,
         absolute_import_prefix: str,
-        all_internal_modules: Set[str],
+        all_internal_modules: set[str],
     ) -> str:
         """If the user specifies a module import start point that is not the root path, the ast module names will not contain
         the root path. Hence, they will later be flagged as external modules.

--- a/src/pytestarch/eval_structure_generation/file_import/import_filter.py
+++ b/src/pytestarch/eval_structure_generation/file_import/import_filter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from pytestarch.eval_structure.types import Import
 

--- a/src/pytestarch/eval_structure_generation/file_import/import_types.py
+++ b/src/pytestarch/eval_structure_generation/file_import/import_types.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
-from typing import List, Optional
 
 from pytestarch.eval_structure.types import Import, get_parent_modules
 from pytestarch.eval_structure_generation.file_import.exceptions import ImportException
@@ -32,7 +31,7 @@ class AbsoluteImport(Import):
     def importee(self) -> str:
         return self._module_name
 
-    def importee_parent_modules(self) -> List[str]:
+    def importee_parent_modules(self) -> list[str]:
         return self._importee_module_hierarchy
 
 
@@ -42,8 +41,8 @@ class RelativeImport(Import):
     def __init__(
         self,
         importer: str,
-        module_name: Optional[str],
-        import_name: Optional[str],
+        module_name: str | None,
+        import_name: str | None,
         level: int,
     ) -> None:
         super().__init__(importer)
@@ -61,7 +60,7 @@ class RelativeImport(Import):
     def importee(self) -> str:
         return self._importee
 
-    def importee_parent_modules(self) -> List[str]:
+    def importee_parent_modules(self) -> list[str]:
         return self._importee_module_hierarchy
 
     def _calculate_importee(self) -> str:

--- a/src/pytestarch/eval_structure_generation/file_import/importee_module_calculator.py
+++ b/src/pytestarch/eval_structure_generation/file_import/importee_module_calculator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Sequence, Set
 
 from pytestarch.eval_structure.types import Import
 
@@ -15,8 +15,8 @@ class ImporteeModuleCalculator:
     def calculate_importee_modules(
         self,
         imports: Sequence[Import],
-        all_modules: List[str],
-    ) -> List[str]:
+        all_modules: list[str],
+    ) -> list[str]:
         """For all imported modules: Calculate parent modules and add them to the list of existing modules if they
         are not already part of this list. This mainly applies to external dependencies.
 
@@ -37,7 +37,7 @@ class ImporteeModuleCalculator:
 
         return list(extended_modules)
 
-    def _calculate_parent_modules(self, imp: Import) -> Set[str]:
+    def _calculate_parent_modules(self, imp: Import) -> set[str]:
         modules = {imp.importee()}
         modules.update(imp.importee_parent_modules())
 

--- a/src/pytestarch/eval_structure_generation/file_import/parser.py
+++ b/src/pytestarch/eval_structure_generation/file_import/parser.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import ast
 import os
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 from pytestarch.eval_structure_generation.file_import.file_filter import FileFilter
 from pytestarch.eval_structure_generation.file_import.import_types import NamedModule
@@ -18,7 +17,7 @@ class Parser:
         self._filter = filter
         self._source_root = source_root
 
-    def parse(self, path: Path) -> Tuple[List[str], List[NamedModule]]:
+    def parse(self, path: Path) -> tuple[list[str], list[NamedModule]]:
         """Reads all python files in the given path and returns list of ast
         modules with names.
 
@@ -48,11 +47,11 @@ class Parser:
 
         return self._all_modules, modules
 
-    def _parse_file(self, path: Path) -> Optional[NamedModule]:
+    def _parse_file(self, path: Path) -> NamedModule | None:
         """Converts a given python file to an ast module and its name."""
         absolute_path = path.resolve()
         if self._file_should_be_parsed(absolute_path):
-            with open(absolute_path, "r") as file:
+            with open(absolute_path) as file:
                 code = file.read()
 
             module_name = self._get_module_name(path)

--- a/src/pytestarch/eval_structure_generation/graph_generation/graph_generator.py
+++ b/src/pytestarch/eval_structure_generation/graph_generation/graph_generator.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Optional, Sequence, Set, Tuple
 
 from pytestarch.eval_structure.evaluable_graph import EvaluableArchitectureGraph
 from pytestarch.eval_structure.networkxgraph import NetworkxGraph, Node
@@ -33,9 +33,9 @@ def generate_graph(
     root_path: Path,
     module_path: Path,
     path_diff_between_root_and_module: str,
-    exclusions: Tuple[str, ...],
+    exclusions: tuple[str, ...],
     exclude_external_libraries: bool,
-    level_limit: Optional[int],
+    level_limit: int | None,
 ) -> EvaluableArchitectureGraph:
     level_limit = _add_extra_levels_to_limit_if_root_and_module_path_differ(
         level_limit,
@@ -67,11 +67,11 @@ def generate_graph(
 
 
 def _append_external_modules_to_module_list(
-    all_modules: List[Node],
+    all_modules: list[Node],
     exclude_external_libraries: bool,
     imports: Sequence[Import],
     root_path: Path,
-) -> List[Node]:
+) -> list[Node]:
     """External modules are not detected as modules when importing the source folder - but they will of course show up
     in the imports. To ensure that all edges in the graph have nodes attached, the external modules need to be added to
     the list of modules/nodes."""
@@ -114,8 +114,8 @@ def _actual_difference_between_root_and_module(
 
 
 def _add_extra_levels_to_limit_if_root_and_module_path_differ(
-    level_limit: Optional[int], path_diff_between_root_and_module: str
-) -> Optional[int]:
+    level_limit: int | None, path_diff_between_root_and_module: str
+) -> int | None:
     """If the root and base module are not the same, the level limit needs to be increased by the number of levels
     between these two modules. Otherwise, the actual base module might not even be in the graph, let alone all required
     levels below it."""
@@ -130,17 +130,17 @@ def _add_extra_levels_to_limit_if_root_and_module_path_differ(
 
 
 def _get_imports_from_ast(
-    ast: List[NamedModule],
+    ast: list[NamedModule],
     absolute_import_prefix: str,
-    all_internal_modules: Set[str],
+    all_internal_modules: set[str],
 ) -> Sequence[Import]:
     converter = ImportConverter()
     return converter.convert(ast, absolute_import_prefix, all_internal_modules)
 
 
 def _get_all_ast_modules(
-    module_path: Path, root_path: Path, exclusions: Tuple[str, ...]
-) -> Tuple[List[str], List[NamedModule]]:
+    module_path: Path, root_path: Path, exclusions: tuple[str, ...]
+) -> tuple[list[str], list[NamedModule]]:
     config = Config(exclusions)
     file_filter = FileFilter(config)
 
@@ -150,6 +150,6 @@ def _get_all_ast_modules(
 
 
 def _get_all_internal_modules(
-    modules: List[str], internal_module_prefix: str
-) -> Set[str]:
+    modules: list[str], internal_module_prefix: str
+) -> set[str]:
     return {m for m in modules if m.startswith(internal_module_prefix)}

--- a/src/pytestarch/pytestarch.py
+++ b/src/pytestarch/pytestarch.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from types import ModuleType
-from typing import Optional, Tuple
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure_generation.graph_generation.graph_generator import (
@@ -25,10 +24,10 @@ DEFAULT_EXCLUSIONS = ("*__pycache__*",)
 def get_evaluable_architecture(
     root_path: str,
     module_path: str,
-    exclusions: Tuple[str, ...] = DEFAULT_EXCLUSIONS,
+    exclusions: tuple[str, ...] = DEFAULT_EXCLUSIONS,
     exclude_external_libraries: bool = True,
-    level_limit: Optional[int] = None,
-    regex_exclusions: Optional[Tuple[str, ...]] = None,
+    level_limit: int | None = None,
+    regex_exclusions: tuple[str, ...] | None = None,
 ) -> EvaluableArchitecture:
     """Constructs an evaluable object based on the given module.
 
@@ -75,10 +74,10 @@ def get_evaluable_architecture(
 def get_evaluable_architecture_for_module_objects(
     root_module: ModuleType,
     module: ModuleType,
-    exclusions: Tuple[str, ...] = DEFAULT_EXCLUSIONS,
+    exclusions: tuple[str, ...] = DEFAULT_EXCLUSIONS,
     exclude_external_libraries: bool = True,
-    level_limit: Optional[int] = None,
-    regex_exclusions: Optional[Tuple[str, ...]] = None,
+    level_limit: int | None = None,
+    regex_exclusions: tuple[str, ...] | None = None,
 ) -> EvaluableArchitecture:
     """Same functionality as get_evaluable_architecture, but root module and module to evaluate are passed in as module objects
     instead of the absolute paths to them.

--- a/src/pytestarch/query_language/base_language.py
+++ b/src/pytestarch/query_language/base_language.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Generic, List, TypeVar, Union
+from typing import Generic, TypeVar, Union
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.utils.decorators import deprecated
@@ -89,20 +89,20 @@ class ModuleSpecification(Generic[ModuleSpecificationSuccessor], ABC):
 
     @abstractmethod
     def are_sub_modules_of(
-        self, modules: Union[str, List[str]]
+        self, modules: str | list[str]
     ) -> ModuleSpecificationSuccessor:
         """If multiple rule subjects are specified, this has the same effect as defining a rule per rule subject."""
         pass
 
     @abstractmethod
-    def are_named(self, names: Union[str, List[str]]) -> ModuleSpecificationSuccessor:
+    def are_named(self, names: str | list[str]) -> ModuleSpecificationSuccessor:
         """If multiple rule subjects are specified, this has the same effect as defining a rule per rule subject."""
         pass
 
     @deprecated
     @abstractmethod
     def have_name_containing(
-        self, partial_name: Union[str, List[str]]
+        self, partial_name: str | list[str]
     ) -> ModuleSpecificationSuccessor:
         """
         [DEPRECATED] Use have_name_matching instead; method will be removed in upcoming releases.
@@ -177,9 +177,7 @@ class LayerDefinition(ABC):
     or multiple modules."""
 
     @abstractmethod
-    def containing_modules(
-        self, modules: Union[str, List[str]]
-    ) -> BaseLayeredArchitecture:
+    def containing_modules(self, modules: str | list[str]) -> BaseLayeredArchitecture:
         """If a module is defined as belonging to layer X, then its submodules are also assumed to be part of layer X."""
         pass
 
@@ -250,7 +248,7 @@ LayerSpecificationSuccessor = TypeVar(
     "LayerSpecificationSuccessor", LayerBehaviorSpecification, RuleApplier
 )
 
-InputTypes = TypeVar("InputTypes", str, Union[str, List[str]])
+InputTypes = TypeVar("InputTypes", str, Union[str, list[str]])
 
 
 class LayerSpecification(Generic[LayerSpecificationSuccessor, InputTypes], ABC):
@@ -261,7 +259,7 @@ class LayerSpecification(Generic[LayerSpecificationSuccessor, InputTypes], ABC):
         pass
 
 
-class LayerRuleObject(LayerSpecification[RuleApplier, Union[str, List[str]]], ABC):
+class LayerRuleObject(LayerSpecification[RuleApplier, Union[str, list[str]]], ABC):
     pass
 
 

--- a/src/pytestarch/query_language/layered_architecture_rule.py
+++ b/src/pytestarch/query_language/layered_architecture_rule.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import partial
-from typing import Dict, List, Optional, Sequence, Tuple, Type, Union
 
 from pytestarch import EvaluableArchitecture, Rule
 from pytestarch.eval_structure.evaluable_architecture import (
@@ -38,7 +38,7 @@ class LayeredArchitecture(BaseLayeredArchitecture, LayerName, LayerDefinition):
     layer L as well."""
 
     def __init__(self) -> None:
-        self._modules_by_layer_name: Dict[str, Sequence[ModuleFilter]] = {}
+        self._modules_by_layer_name: dict[str, Sequence[ModuleFilter]] = {}
 
     @property
     def layer_mapping(self) -> LayerMapping:
@@ -63,7 +63,7 @@ class LayeredArchitecture(BaseLayeredArchitecture, LayerName, LayerDefinition):
 
         return self
 
-    def _get_layers_without_modules(self) -> List[str]:
+    def _get_layers_without_modules(self) -> list[str]:
         underspecified_layers = [
             layer
             for layer, modules in self._modules_by_layer_name.items()
@@ -71,7 +71,7 @@ class LayeredArchitecture(BaseLayeredArchitecture, LayerName, LayerDefinition):
         ]
         return underspecified_layers
 
-    def containing_modules(self, modules: Union[str, List[str]]) -> LayeredArchitecture:
+    def containing_modules(self, modules: str | list[str]) -> LayeredArchitecture:
         layers_without_modules = self._get_layers_without_modules()
         if not layers_without_modules or len(layers_without_modules) > 1:
             raise ImproperlyConfigured(
@@ -128,7 +128,7 @@ class LayeredArchitecture(BaseLayeredArchitecture, LayerName, LayerDefinition):
     def __getitem__(self, layer: str) -> Sequence[ModuleFilter]:
         return self._modules_by_layer_name[layer]
 
-    def _to_module_objects(self, modules: List[str]) -> Sequence[ModuleFilter]:
+    def _to_module_objects(self, modules: list[str]) -> Sequence[ModuleFilter]:
         return [ModuleNameFilter(name=module) for module in modules]
 
     def _from_regex_to_module_objects(self, regex: str) -> Sequence[ModuleFilter]:
@@ -151,10 +151,10 @@ class LayerRule(
     """
 
     def __init__(
-        self, rule_matcher_class: Type[RuleMatcher] = LayerRuleMatcher
+        self, rule_matcher_class: type[RuleMatcher] = LayerRuleMatcher
     ) -> None:
         self._rule = None
-        self._architecture: Optional[LayeredArchitecture] = None
+        self._architecture: LayeredArchitecture | None = None
         self._rule_matcher_class = rule_matcher_class
 
     def based_on(self, architecture: LayeredArchitecture) -> LayerBase:
@@ -174,7 +174,7 @@ class LayerRule(
 
         return self
 
-    def are_named(self, layers: Union[str, List[str]]) -> LayerBehaviorSpecification:
+    def are_named(self, layers: str | list[str]) -> LayerBehaviorSpecification:
         if self._rule is None:
             raise ImproperlyConfigured(
                 "Please start with 'layers_that' to ensure the rule is properly set up."
@@ -261,10 +261,10 @@ class LayerRule(
         self._rule.assert_applies(evaluable)
 
     @classmethod
-    def _listify(cls, layers: Union[str, List[str]]) -> List[str]:
-        return layers if isinstance(layers, List) else [layers]
+    def _listify(cls, layers: str | list[str]) -> list[str]:
+        return layers if isinstance(layers, list) else [layers]
 
-    def _get_all_modules_in_layers(self, layers: List[str]) -> List[Tuple[str, bool]]:
+    def _get_all_modules_in_layers(self, layers: list[str]) -> list[tuple[str, bool]]:
         if self._architecture is None:
             raise ImproperlyConfigured(
                 "Please specify an architecture to base the layers on first."

--- a/src/pytestarch/query_language/multiple_rule_applier.py
+++ b/src/pytestarch/query_language/multiple_rule_applier.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import List
-
 from pytestarch import EvaluableArchitecture
 from pytestarch.query_language.base_language import RuleApplier
 
 
 class MultipleRuleApplier(RuleApplier):
-    def __init__(self, rule_appliers: List[RuleApplier]) -> None:
+    def __init__(self, rule_appliers: list[RuleApplier]) -> None:
         self._rule_appliers = rule_appliers
 
     def assert_applies(self, evaluable: EvaluableArchitecture) -> None:

--- a/src/pytestarch/query_language/rule.py
+++ b/src/pytestarch/query_language/rule.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
-from typing import Callable, List, Optional, Sequence, Tuple, Union
+from typing import Callable
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure.evaluable_architecture import (
@@ -35,13 +36,13 @@ from pytestarch.utils.partial_match_to_regex_converter import (
 
 @dataclass
 class RuleConfiguration:
-    modules_to_check: Optional[Sequence[ModuleFilter]] = None
-    modules_to_check_against: Optional[Sequence[ModuleFilter]] = None
+    modules_to_check: Sequence[ModuleFilter] | None = None
+    modules_to_check_against: Sequence[ModuleFilter] | None = None
     should: bool = False
     should_only: bool = False
     should_not: bool = False
     except_present: bool = False
-    import_: Optional[bool] = None
+    import_: bool | None = None
     rule_object_anything: bool = False
 
 
@@ -64,11 +65,11 @@ class Rule(
         ] = DefaultRuleMatcher,
     ) -> None:
         self._rule_matcher_class = rule_matcher_class
-        self._modules_to_check_to_be_specified_next: Optional[bool] = None
+        self._modules_to_check_to_be_specified_next: bool | None = None
         self._configuration = RuleConfiguration()
 
     @property
-    def rule_subjects(self) -> Optional[Sequence[ModuleFilter]]:
+    def rule_subjects(self) -> Sequence[ModuleFilter] | None:
         return self._configuration.modules_to_check
 
     def modules_that(self) -> RuleSubject:
@@ -76,20 +77,20 @@ class Rule(
         return self
 
     def are_sub_modules_of(  # type: ignore
-        self, modules: Union[str, List[str]]
+        self, modules: str | list[str]
     ) -> BehaviorSpecification:
         self._set_modules(
             modules, lambda name: ParentModuleNameFilter(parent_module=name)
         )
         return self
 
-    def are_named(self, names: Union[str, List[str]]) -> BehaviorSpecification:  # type: ignore
+    def are_named(self, names: str | list[str]) -> BehaviorSpecification:  # type: ignore
         self._set_modules(names, lambda name: ModuleNameFilter(name=name))
         return self
 
     @deprecated
     def have_name_containing(
-        self, partial_names: Union[str, List[str]]
+        self, partial_names: str | list[str]
     ) -> BehaviorSpecification:
         self._set_modules(
             partial_names,
@@ -108,7 +109,7 @@ class Rule(
 
     def _set_modules(
         self,
-        module_names: Union[str, List[str]],
+        module_names: str | list[str],
         create_module_fn: Callable[[str], ModuleFilter],
     ) -> None:
         if self._modules_to_check_to_be_specified_next is None:
@@ -123,7 +124,7 @@ class Rule(
         else:
             self._configuration.modules_to_check_against = modules
 
-    def _add_modules(self, modules: List[Tuple[str, bool]]) -> BehaviorSpecification:
+    def _add_modules(self, modules: list[tuple[str, bool]]) -> BehaviorSpecification:
         module_names = []
         module_creation_fn = []
 
@@ -142,8 +143,8 @@ class Rule(
 
     def _append_modules(
         self,
-        module_names: List[str],
-        create_module_fns: List[Callable[[str], ModuleFilter]],
+        module_names: list[str],
+        create_module_fns: list[Callable[[str], ModuleFilter]],
     ) -> None:
         modules = [fn(n) for n, fn in zip(module_names, create_module_fns)]
         if self._modules_to_check_to_be_specified_next:
@@ -328,7 +329,7 @@ class Rule(
     @classmethod
     def _get_modules_to_check_without_parent_and_submodule_combinations(
         cls, configuration: RuleConfiguration
-    ) -> Optional[Sequence[ModuleFilter]]:
+    ) -> Sequence[ModuleFilter] | None:
         # if modules_to_check contain a module and its submodule, this can throw off the breadth first search conducted
         # on the dependency graph - and also, this setup does not really make sense
         if configuration.modules_to_check is None:

--- a/src/pytestarch/rule_assessment/error_message/message_generator.py
+++ b/src/pytestarch/rule_assessment/error_message/message_generator.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import DefaultDict, Dict, Iterable, List, Optional, Set, Tuple, cast
+from typing import cast
 
 from pytestarch.eval_structure.evaluable_architecture import (
     Dependency,
@@ -36,7 +37,7 @@ class RuleViolatedMessage:
 
 
 # (Import, negated, subject singular)
-PREFIX_MAPPING: DefaultDict[Tuple[bool, bool, bool], str] = defaultdict(str)
+PREFIX_MAPPING: defaultdict[tuple[bool, bool, bool], str] = defaultdict(str)
 PREFIX_MAPPING.update(
     {
         (False, False, True): "is ",
@@ -55,7 +56,7 @@ class RuleViolationMessageBaseGenerator(ABC):
 
     def create_rule_violation_messages(
         self, rule_violations: RuleViolations
-    ) -> List[str]:
+    ) -> list[str]:
         """Create a message about each rule violation.
 
         Args:
@@ -74,8 +75,8 @@ class RuleViolationMessageBaseGenerator(ABC):
 
     def _create_violation_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         self._extend(
             messages, self._create_should_import_violated_messages(rule_violations)
@@ -103,8 +104,8 @@ class RuleViolationMessageBaseGenerator(ABC):
 
     def _extend(
         self,
-        messages: List[RuleViolatedMessage],
-        new_messages: Optional[List[RuleViolatedMessage]],
+        messages: list[RuleViolatedMessage],
+        new_messages: list[RuleViolatedMessage] | None,
     ) -> None:
         if new_messages is not None:
             messages.extend(new_messages)
@@ -112,37 +113,37 @@ class RuleViolationMessageBaseGenerator(ABC):
     @abstractmethod
     def _create_should_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         pass
 
     @abstractmethod
     def _create_should_only_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         pass
 
     @abstractmethod
     def _create_should_not_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         pass
 
     @abstractmethod
     def _create_should_import_except_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         pass
 
     @abstractmethod
     def _create_should_only_import_except_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         pass
 
     @abstractmethod
     def _create_should_not_import_except_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         pass
 
 
@@ -160,15 +161,15 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _create_should_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_no_import_between_original_subject_and_objects_message(
             rule_violations.should_violations
         )
 
     def _create_no_import_between_original_subject_and_objects_message(
         self, rule_violations: Iterable[Dependency]
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         (
             rule_objects_for_rule_subject,
@@ -196,8 +197,8 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _add_combined_rule_objects(
         self,
-        messages: List[RuleViolatedMessage],
-        rule_objects: List[str],
+        messages: list[RuleViolatedMessage],
+        rule_objects: list[str],
         rule_subject: str,
         rule_verb: str,
     ) -> None:
@@ -209,7 +210,7 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _get_violating_rule_subjects_and_objects(
         self, rule_violation_dependencies: Iterable[Dependency]
-    ) -> Tuple[Dict[Module, List[Module]], Set[Module]]:
+    ) -> tuple[dict[Module, list[Module]], set[Module]]:
         violating_rule_subjects = set()
         rule_objects_for_rule_subject = defaultdict(list)
         for rule_subject, rule_object in rule_violation_dependencies:
@@ -219,8 +220,8 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
         return rule_objects_for_rule_subject, violating_rule_subjects
 
     def _convert_to_names(
-        self, violating_dependencies: List[Dependency]
-    ) -> List[Tuple[str, str]]:
+        self, violating_dependencies: list[Dependency]
+    ) -> list[tuple[str, str]]:
         return [
             (dependency[0].identifier, dependency[1].identifier)
             for dependency in violating_dependencies
@@ -228,8 +229,8 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _create_should_only_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         self._extend(
             messages,
@@ -248,7 +249,7 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _create_should_only_import_forbidden_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_other_violating_dependencies_message(
             rule_violations.should_only_violations_by_forbidden_import
         )
@@ -256,7 +257,7 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
     def _create_other_violating_dependencies_message(
         self,
         violating_dependencies: Iterable[Dependency],
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         # messages are always of the type "module x imports module y"
         messages = []
 
@@ -279,29 +280,29 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _create_should_only_import_no_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_no_import_between_original_subject_and_objects_message(
             rule_violations.should_only_violations_by_no_import
         )
 
     def _create_should_not_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_other_violating_dependencies_message(
             rule_violations.should_not_violations
         )
 
     def _create_should_import_except_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_no_import_other_than_between_original_subject_and_objects_message(
             rule_violations.should_except_violations
         )
 
     def _create_no_import_other_than_between_original_subject_and_objects_message(
         self, rule_violations: Iterable[Dependency]
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         (
             rule_objects_for_rule_subject,
@@ -331,8 +332,8 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _add_combined_any_rule_objects(
         self,
-        messages: List[RuleViolatedMessage],
-        rule_objects: List[str],
+        messages: list[RuleViolatedMessage],
+        rule_objects: list[str],
         rule_subject: str,
         rule_verb: str,
         rule_object_type: str = ANY_MODULE_THAT_IS_NOT,
@@ -346,8 +347,8 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _create_should_only_import_except_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         self._extend(
             messages,
@@ -366,21 +367,21 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _create_should_only_import_except_forbidden_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_other_violating_dependencies_message(
             rule_violations.should_only_except_violations_by_forbidden_import
         )
 
     def _create_should_only_import_except_no_import_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_no_import_other_than_between_original_subject_and_objects_message(
             rule_violations.should_only_except_violations_by_no_import
         )
 
     def _create_should_not_import_except_violated_messages(
         self, rule_violations: RuleViolations
-    ) -> List[RuleViolatedMessage]:
+    ) -> list[RuleViolatedMessage]:
         return self._create_other_violating_dependencies_message(
             rule_violations.should_not_except_violations
         )
@@ -419,7 +420,7 @@ class RuleViolationMessageGenerator(RuleViolationMessageBaseGenerator):
 
     def _get_rule_subject_and_object_of_dependency(
         self, dependency: Dependency
-    ) -> Tuple[str, str]:
+    ) -> tuple[str, str]:
         rule_subject_name = self._get_module_name(dependency[0])
         rule_object_name = self._get_module_name(dependency[1])
 
@@ -472,8 +473,8 @@ class LayerRuleViolationMessageGenerator(RuleViolationMessageGenerator):
 
     def _create_no_import_between_original_subject_and_objects_message(
         self, rule_violations: Iterable[Dependency]
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         (
             rule_object_layers_for_rule_subject_layer,
@@ -507,7 +508,7 @@ class LayerRuleViolationMessageGenerator(RuleViolationMessageGenerator):
 
     def _get_violating_rule_subject_and_objects_layers(
         self, rule_violation_dependencies: Iterable[Dependency]
-    ) -> Tuple[DefaultDict[str, Set[str]], Set[str]]:
+    ) -> tuple[defaultdict[str, set[str]], set[str]]:
         violating_rule_subject_layers = set()
         rule_object_layers_for_rule_subject_layer = defaultdict(set)
 
@@ -530,8 +531,8 @@ class LayerRuleViolationMessageGenerator(RuleViolationMessageGenerator):
 
     def _create_no_import_other_than_between_original_subject_and_objects_message(
         self, rule_violations: Iterable[Dependency]
-    ) -> List[RuleViolatedMessage]:
-        messages: List[RuleViolatedMessage] = []
+    ) -> list[RuleViolatedMessage]:
+        messages: list[RuleViolatedMessage] = []
 
         (
             rule_object_layers_for_rule_subject,

--- a/src/pytestarch/rule_assessment/rule_check/layer_rule_violation_detector.py
+++ b/src/pytestarch/rule_assessment/rule_check/layer_rule_violation_detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, DefaultDict, Dict, List, Optional, Set, Tuple
+from typing import Any
 
 from pytestarch.eval_structure.evaluable_architecture import (
     Dependency,
@@ -39,10 +39,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_not_requirement_violations(
         self,
         explicitly_requested_dependencies_should_not_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_should_not_be_present
@@ -54,10 +54,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_requirement_violations(
         self,
         explicitly_requested_dependencies_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_should_be_present
@@ -71,10 +71,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_requirement_violations_by_no_import(
         self,
         explicitly_requested_dependencies_and_no_other_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_and_no_other_should_be_present
@@ -88,10 +88,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_requirement_violations_by_not_explicitly_requested_dependency(
         self,
         explicitly_requested_dependencies_and_no_other_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_and_no_other_should_be_present
@@ -103,10 +103,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_except_requirement_violations(
         self,
         at_least_one_not_explicitly_requested_dependency_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not at_least_one_not_explicitly_requested_dependency_should_be_present
@@ -120,10 +120,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_except_requirement_violations_due_to_no_other_imports(
         self,
         explicitly_requested_dependency_should_not_but_others_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not explicitly_requested_dependency_should_not_but_others_should_be_present
@@ -137,10 +137,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_except_requirement_violations_due_to_explicit_dependency_present(
         self,
         explicitly_requested_dependency_should_not_but_others_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependency_should_not_but_others_should_be_present
@@ -152,10 +152,10 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _should_not_except_requirement_violations(
         self,
         not_explicitly_requested_dependencies_should_not_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not not_explicitly_requested_dependencies_should_not_be_present
@@ -166,8 +166,8 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
 
     def _get_abstract_dependencies_without_any_realisations(
         self,
-        explicitly_requested_dependencies: Dict[Dependency, List[Dependency]],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: dict[Dependency, list[Dependency]],
+    ) -> set[Dependency]:
         """If there is any explicitly requested dependency for each rule object, an empty list will be returned. If there is none at all for at least one rule object,
         all dependencies will be returned."""
         explicitly_requested_dependencies_by_layers = (
@@ -176,7 +176,7 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
             )
         )
 
-        result: Set[Tuple[Module, Module]] = set()  # type: ignore
+        result: set[tuple[Module, Module]] = set()  # type: ignore
 
         for layer in self._layer_to_module_mapping.all_layers:
             explicitly_requested_dependencies_for_layer = (
@@ -205,7 +205,7 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _get_any_missing_dependencies_in_user_specified_order(
         self,
         not_explicitly_requested_dependencies: NotExplicitlyRequestedDependenciesByBaseModule,
-    ) -> Set[Dependency]:
+    ) -> set[Dependency]:
         """If no not explicitly requested dependency is present, all possible not present dependencies will be
         returned. If there is one dependency per rule subject, an empty list will be returned.
         """
@@ -227,7 +227,7 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _append_missing_dependencies(
         self,
         not_explicitly_requested_dependencies: NotExplicitlyRequestedDependenciesByBaseModule,
-    ) -> List[Dependency]:
+    ) -> list[Dependency]:
         dependencies = []
 
         for (
@@ -249,8 +249,8 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
     def _group_explicitly_requested_dependencies_by_layers(
         self,
         explicitly_requested_dependencies: ExplicitlyRequestedDependenciesByBaseModules,
-    ) -> DefaultDict[Layer, ExplicitlyRequestedDependenciesByBaseModules]:
-        result: DefaultDict[Layer, ExplicitlyRequestedDependenciesByBaseModules] = (
+    ) -> defaultdict[Layer, ExplicitlyRequestedDependenciesByBaseModules]:
+        result: defaultdict[Layer, ExplicitlyRequestedDependenciesByBaseModules] = (
             defaultdict(dict)
         )
 
@@ -279,8 +279,8 @@ class LayerRuleViolationDetector(RuleViolationBaseDetector):
         )
 
     def _get_realised_dependencies(
-        self, explicitly_requested_dependencies: Dict[Any, List[Dependency]]
-    ) -> Set[Dependency]:
+        self, explicitly_requested_dependencies: dict[Any, list[Dependency]]
+    ) -> set[Dependency]:
         """Removes all dependencies between modules of the same layer, as these are one logical unit."""
         violating_dependencies = super()._get_realised_dependencies(
             explicitly_requested_dependencies

--- a/src/pytestarch/rule_assessment/rule_check/module_requirement.py
+++ b/src/pytestarch/rule_assessment/rule_check/module_requirement.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from pytestarch.eval_structure.evaluable_architecture import ModuleFilter
 

--- a/src/pytestarch/rule_assessment/rule_check/rule_matcher.py
+++ b/src/pytestarch/rule_assessment/rule_check/rule_matcher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Dict, List, Optional
 
 from pytestarch.eval_structure.evaluable_architecture import (
     EvaluableArchitecture,
@@ -80,7 +79,7 @@ class RuleMatcher(ABC):
 
     @abstractmethod
     def _get_rule_violation_detector(
-        self, module_name_conversion_mapping: Dict[str, List[Module]]
+        self, module_name_conversion_mapping: dict[str, list[Module]]
     ) -> RuleViolationBaseDetector:
         pass
 
@@ -96,7 +95,7 @@ class RuleMatcher(ABC):
 
     def _get_not_explicitly_requested_dependencies(
         self, evaluable: EvaluableArchitecture
-    ) -> Optional[NotExplicitlyRequestedDependenciesByBaseModule]:
+    ) -> NotExplicitlyRequestedDependenciesByBaseModule | None:
         if (
             self._behavior_requirement.not_explicitly_requested_dependency_required
             or self._behavior_requirement.not_explicitly_requested_dependency_not_allowed
@@ -122,7 +121,7 @@ class RuleMatcher(ABC):
     def _get_explicitly_requested_dependencies(
         self,
         evaluable: EvaluableArchitecture,
-    ) -> Optional[ExplicitlyRequestedDependenciesByBaseModules]:
+    ) -> ExplicitlyRequestedDependenciesByBaseModules | None:
         if (
             self._behavior_requirement.explicitly_requested_dependency_required
             or self._behavior_requirement.explicitly_requested_dependency_not_allowed
@@ -156,7 +155,7 @@ class RuleMatcher(ABC):
             self._module_requirement.rule_specified_with_importer_as_rule_subject,
         )
 
-    def _create_module_name_regex_conversion_mapping(self) -> Dict[str, List[Module]]:
+    def _create_module_name_regex_conversion_mapping(self) -> dict[str, list[Module]]:
         """Maps between a regex and the actual modules it represents."""
 
         result = {
@@ -179,7 +178,7 @@ class DefaultRuleMatcher(RuleMatcher):
     """To be used for rules that operate on modules, such as "module X should not import module Y."""
 
     def _get_rule_violation_detector(
-        self, _: Dict[str, List[Module]]
+        self, _: dict[str, list[Module]]
     ) -> RuleViolationBaseDetector:
         return RuleViolationDetector(
             self._updated_module_requirement, self._behavior_requirement
@@ -210,7 +209,7 @@ class LayerRuleMatcher(RuleMatcher):
         self._layer_mapping = layer_mapping
 
     def _get_rule_violation_detector(
-        self, module_name_conversion_mapping: Dict[str, List[Module]]
+        self, module_name_conversion_mapping: dict[str, list[Module]]
     ) -> RuleViolationBaseDetector:
         self._updated_layer_mapping = self._update_layer_mapping(
             self._layer_mapping, module_name_conversion_mapping
@@ -233,7 +232,7 @@ class LayerRuleMatcher(RuleMatcher):
     def _update_layer_mapping(
         cls,
         layer_mapping: LayerMapping,
-        module_name_conversion_mapping: Dict[str, List[Module]],
+        module_name_conversion_mapping: dict[str, list[Module]],
     ) -> LayerMapping:
         return LayerMapping(
             {
@@ -249,8 +248,8 @@ class LayerRuleMatcher(RuleMatcher):
         cls,
         layer: Layer,
         layer_mapping: LayerMapping,
-        module_name_conversion_mapping: Dict[str, List[Module]],
-    ) -> List[Module]:
+        module_name_conversion_mapping: dict[str, list[Module]],
+    ) -> list[Module]:
         modules_potentially_with_regexes = layer_mapping.get_module_filters(layer)
 
         result = []

--- a/src/pytestarch/rule_assessment/rule_check/rule_violation_detector.py
+++ b/src/pytestarch/rule_assessment/rule_check/rule_violation_detector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Set
+from typing import Any
 
 from pytestarch.eval_structure.evaluable_architecture import (
     Dependency,
@@ -42,12 +42,12 @@ class RuleViolationBaseDetector(ABC):
 
     def get_rule_violation(
         self,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
     ) -> RuleViolations:
         """Translate from the detected types of dependencies back to which behavior and dependency requirements are violated by them.
         Args:
@@ -97,85 +97,85 @@ class RuleViolationBaseDetector(ABC):
     def _should_not_requirement_violations(
         self,
         explicitly_requested_dependencies_should_not_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_requirement_violations(
         self,
         explicitly_requested_dependencies_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_only_requirement_violations_by_no_import(
         self,
         explicitly_requested_dependencies_and_no_other_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_only_requirement_violations_by_not_explicitly_requested_dependency(
         self,
         explicitly_requested_dependencies_and_no_other_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_except_requirement_violations(
         self,
         at_least_one_not_explicitly_requested_dependency_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_only_except_requirement_violations_due_to_no_other_imports(
         self,
         explicitly_requested_dependency_should_not_but_others_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_only_except_requirement_violations_due_to_explicit_dependency_present(
         self,
         explicitly_requested_dependency_should_not_but_others_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     @abstractmethod
     def _should_not_except_requirement_violations(
         self,
         not_explicitly_requested_dependencies_should_not_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         pass
 
     def _get_realised_dependencies(
-        self, explicitly_requested_dependencies: Dict[Any, List[Dependency]]
-    ) -> Set[Dependency]:
+        self, explicitly_requested_dependencies: dict[Any, list[Dependency]]
+    ) -> set[Dependency]:
         violating_dependencies = explicitly_requested_dependencies.values()
 
         violating_dependencies_in_user_specified_rule_subject_object_order = set()
@@ -257,10 +257,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_not_requirement_violations(
         self,
         explicitly_requested_dependencies_should_not_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_should_not_be_present
@@ -272,10 +272,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_requirement_violations(
         self,
         explicitly_requested_dependencies_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_should_be_present
@@ -289,10 +289,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_requirement_violations_by_no_import(
         self,
         explicitly_requested_dependencies_and_no_other_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_and_no_other_should_be_present
@@ -306,10 +306,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_requirement_violations_by_not_explicitly_requested_dependency(
         self,
         explicitly_requested_dependencies_and_no_other_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not explicitly_requested_dependencies_and_no_other_should_be_present
@@ -321,10 +321,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_except_requirement_violations(
         self,
         at_least_one_not_explicitly_requested_dependency_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not at_least_one_not_explicitly_requested_dependency_should_be_present
@@ -338,10 +338,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_except_requirement_violations_due_to_no_other_imports(
         self,
         explicitly_requested_dependency_should_not_but_others_should_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not explicitly_requested_dependency_should_not_but_others_should_be_present
@@ -355,10 +355,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_only_except_requirement_violations_due_to_explicit_dependency_present(
         self,
         explicitly_requested_dependency_should_not_but_others_should_be_present: bool,
-        explicitly_requested_dependencies: Optional[
-            ExplicitlyRequestedDependenciesByBaseModules
-        ],
-    ) -> Set[Dependency]:
+        explicitly_requested_dependencies: (
+            ExplicitlyRequestedDependenciesByBaseModules | None
+        ),
+    ) -> set[Dependency]:
         if (
             explicitly_requested_dependencies is None
             or not explicitly_requested_dependency_should_not_but_others_should_be_present
@@ -370,10 +370,10 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _should_not_except_requirement_violations(
         self,
         not_explicitly_requested_dependencies_should_not_be_present: bool,
-        not_explicitly_requested_dependencies: Optional[
-            NotExplicitlyRequestedDependenciesByBaseModule
-        ],
-    ) -> Set[Dependency]:
+        not_explicitly_requested_dependencies: (
+            NotExplicitlyRequestedDependenciesByBaseModule | None
+        ),
+    ) -> set[Dependency]:
         if (
             not_explicitly_requested_dependencies is None
             or not not_explicitly_requested_dependencies_should_not_be_present
@@ -383,8 +383,8 @@ class RuleViolationDetector(RuleViolationBaseDetector):
         return self._get_realised_dependencies(not_explicitly_requested_dependencies)
 
     def _get_abstract_dependencies_without_realisations(
-        self, explicitly_requested_dependencies: Dict[Any, List[Dependency]]
-    ) -> Set[Dependency]:
+        self, explicitly_requested_dependencies: dict[Any, list[Dependency]]
+    ) -> set[Dependency]:
         violating_dependencies = [
             abstract_dependency
             for abstract_dependency, concrete_dependency in explicitly_requested_dependencies.items()
@@ -398,7 +398,7 @@ class RuleViolationDetector(RuleViolationBaseDetector):
     def _get_missing_dependencies_in_user_specified_order(
         self,
         not_explicitly_requested_dependencies: NotExplicitlyRequestedDependenciesByBaseModule,
-    ) -> Set[Dependency]:
+    ) -> set[Dependency]:
         dependencies = []
 
         for (

--- a/src/pytestarch/rule_assessment/rule_check/rule_violations.py
+++ b/src/pytestarch/rule_assessment/rule_check/rule_violations.py
@@ -1,21 +1,20 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, fields
-from typing import Set
 
 from pytestarch.eval_structure.evaluable_architecture import Dependency
 
 
 @dataclass
 class RuleViolations:
-    should_violations: Set[Dependency]
-    should_only_violations_by_forbidden_import: Set[Dependency]
-    should_only_violations_by_no_import: Set[Dependency]
-    should_not_violations: Set[Dependency]
-    should_except_violations: Set[Dependency]
-    should_only_except_violations_by_forbidden_import: Set[Dependency]
-    should_only_except_violations_by_no_import: Set[Dependency]
-    should_not_except_violations: Set[Dependency]
+    should_violations: set[Dependency]
+    should_only_violations_by_forbidden_import: set[Dependency]
+    should_only_violations_by_no_import: set[Dependency]
+    should_not_violations: set[Dependency]
+    should_except_violations: set[Dependency]
+    should_only_except_violations_by_forbidden_import: set[Dependency]
+    should_only_except_violations_by_no_import: set[Dependency]
+    should_not_except_violations: set[Dependency]
 
     def __bool__(self) -> bool:
         return any(self.__dict__[field.name] for field in fields(self))

--- a/tests/eval_structure/evaluable_graph/test_any_dependencies_to_other_modules.py
+++ b/tests/eval_structure/evaluable_graph/test_any_dependencies_to_other_modules.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import pytest
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
@@ -29,7 +27,7 @@ from pytestarch.eval_structure_generation.file_import.import_types import Absolu
         [AbsoluteImport(SUB_MODULE_OF_1, MODULE_3)],
     ],
 )
-def test_any_to_other_between_named_modules(imports: List[AbsoluteImport]) -> None:
+def test_any_to_other_between_named_modules(imports: list[AbsoluteImport]) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
 
@@ -55,7 +53,7 @@ def test_any_to_other_between_named_modules(imports: List[AbsoluteImport]) -> No
     ],
 )
 def test_any_to_other_between_named_and_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -79,7 +77,7 @@ def test_any_to_other_between_named_and_submodule_modules(
     ],
 )
 def test_any_to_other_between_submodule_and_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -103,7 +101,7 @@ def test_any_to_other_between_submodule_and_named_modules(
         [AbsoluteImport(SUB_MODULE_OF_1, MODULE_2)],
     ],
 )
-def test_any_to_other_between_submodule_modules(imports: List[AbsoluteImport]) -> None:
+def test_any_to_other_between_submodule_modules(imports: list[AbsoluteImport]) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
 
@@ -128,7 +126,7 @@ def test_any_to_other_between_submodule_modules(imports: List[AbsoluteImport]) -
         [AbsoluteImport(SUB_MODULE_OF_1, SUB_MODULE_OF_2)],
     ],
 )
-def test_not_any_to_other_between_named_modules(imports: List[AbsoluteImport]) -> None:
+def test_not_any_to_other_between_named_modules(imports: list[AbsoluteImport]) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
 
@@ -152,7 +150,7 @@ def test_not_any_to_other_between_named_modules(imports: List[AbsoluteImport]) -
     ],
 )
 def test_not_any_to_other_between_named_and_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -178,7 +176,7 @@ def test_not_any_to_other_between_named_and_submodule_modules(
     ],
 )
 def test_not_any_to_other_between_submodule_and_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -202,7 +200,7 @@ def test_not_any_to_other_between_submodule_and_named_modules(
     ],
 )
 def test_not_any_to_other_between_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))

--- a/tests/eval_structure/evaluable_graph/test_dependencies_between_modules.py
+++ b/tests/eval_structure/evaluable_graph/test_dependencies_between_modules.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import pytest
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
@@ -398,7 +396,7 @@ def test_depends_on(evaluable: EvaluableArchitecture) -> None:
         [AbsoluteImport(SUB_MODULE_OF_1, MODULE_2)],
     ],
 )
-def test_is_dependent_between_named_modules(imports: List[AbsoluteImport]) -> None:
+def test_is_dependent_between_named_modules(imports: list[AbsoluteImport]) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
 
@@ -421,7 +419,7 @@ def test_is_dependent_between_named_modules(imports: List[AbsoluteImport]) -> No
     ],
 )
 def test_is_dependent_between_named_and_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -445,7 +443,7 @@ def test_is_dependent_between_named_and_submodule_modules(
     ],
 )
 def test_is_dependent_between_submodule_and_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -467,7 +465,7 @@ def test_is_dependent_between_submodule_and_named_modules(
         [AbsoluteImport(SUB_MODULE_OF_1, SUB_MODULE_OF_2)],
     ],
 )
-def test_is_dependent_between_submodule_modules(imports: List[AbsoluteImport]) -> None:
+def test_is_dependent_between_submodule_modules(imports: list[AbsoluteImport]) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
 
@@ -489,7 +487,7 @@ def test_is_dependent_between_submodule_modules(imports: List[AbsoluteImport]) -
         [AbsoluteImport(SUB_MODULE_OF_2, SUB_MODULE_OF_2)],
     ],
 )
-def test_is_not_dependent_between_named_modules(imports: List[AbsoluteImport]) -> None:
+def test_is_not_dependent_between_named_modules(imports: list[AbsoluteImport]) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
 
@@ -512,7 +510,7 @@ def test_is_not_dependent_between_named_modules(imports: List[AbsoluteImport]) -
     ],
 )
 def test_is_not_dependent_between_named_and_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -535,7 +533,7 @@ def test_is_not_dependent_between_named_and_submodule_modules(
     ],
 )
 def test_is_not_dependent_between_submodule_and_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -560,7 +558,7 @@ def test_is_not_dependent_between_submodule_and_named_modules(
     ],
 )
 def test_is_not_dependent_between_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))

--- a/tests/eval_structure/evaluable_graph/test_other_dependencies_towards_modules.py
+++ b/tests/eval_structure/evaluable_graph/test_other_dependencies_towards_modules.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import pytest
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
@@ -30,7 +28,7 @@ from pytestarch.eval_structure_generation.file_import.import_types import Absolu
     ],
 )
 def test_other_to_module_than_between_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -52,7 +50,7 @@ def test_other_to_module_than_between_named_modules(
     ],
 )
 def test_other_to_module_than_between_named_and_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -77,7 +75,7 @@ def test_other_to_module_than_between_named_and_submodule_modules(
     ],
 )
 def test_other_to_module_than_between_submodule_and_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -100,7 +98,7 @@ def test_other_to_module_than_between_submodule_and_named_modules(
     ],
 )
 def test_other_to_module_than_between_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -125,7 +123,7 @@ def test_other_to_module_than_between_submodule_modules(
     ],
 )
 def test_not_other_to_module_than_between_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -151,7 +149,7 @@ def test_not_other_to_module_than_between_named_modules(
     ],
 )
 def test_not_other_to_module_than_between_named_and_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -176,7 +174,7 @@ def test_not_other_to_module_than_between_named_and_submodule_modules(
     ],
 )
 def test_not_other_to_module_than_between_submodule_and_named_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))
@@ -203,7 +201,7 @@ def test_not_other_to_module_than_between_submodule_and_named_modules(
     ],
 )
 def test_not_other_to_module_than_between_submodule_modules(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
 ) -> None:
     all_modules = [MODULE_1, MODULE_2, SUB_MODULE_OF_1, SUB_MODULE_OF_2, MODULE_3]
     architecture = EvaluableArchitectureGraph(NetworkxGraph(all_modules, imports))

--- a/tests/eval_structure/evaluable_graph/test_partial_module_matches.py
+++ b/tests/eval_structure/evaluable_graph/test_partial_module_matches.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 from eval_structure.evaluable_graph.conftest import MODULE_A, MODULE_B, MODULE_D

--- a/tests/eval_structure/test_module_name_converter.py
+++ b/tests/eval_structure/test_module_name_converter.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import List
-
 import pytest
 from integration.interesting_rules_for_tests import PROJECT_ROOT
 
@@ -36,7 +34,7 @@ test_cases = [
 
 @pytest.mark.parametrize("regex, expected_matches", test_cases)
 def test_submodules_are_matched(
-    regex: str, expected_matches: List[str], flat_project_1: EvaluableArchitecture
+    regex: str, expected_matches: list[str], flat_project_1: EvaluableArchitecture
 ) -> None:
     modules_to_convert = [ModuleNameRegexFilter(name=regex)]
 

--- a/tests/eval_structure_generation/test_file_filter.py
+++ b/tests/eval_structure_generation/test_file_filter.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import List, Tuple
 
 import pytest
 
@@ -20,7 +19,7 @@ test_cases = [
 
 
 @pytest.mark.parametrize("input_modules", test_cases)
-def test_import_filter(input_modules: List[str]) -> None:
+def test_import_filter(input_modules: list[str]) -> None:
     config = Config(
         tuple(
             map(
@@ -53,7 +52,7 @@ exclusion_test_cases = [
 
 
 @pytest.mark.parametrize("exclusions", exclusion_test_cases)
-def test_exclude_files_in_directory(exclusions: Tuple[str, ...]) -> None:
+def test_exclude_files_in_directory(exclusions: tuple[str, ...]) -> None:
     config = Config(exclusions)
     filter = FileFilter(config)
 

--- a/tests/eval_structure_generation/test_module_graph.py
+++ b/tests/eval_structure_generation/test_module_graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
-from typing import List, Sequence, Tuple
 
 import pytest
 
@@ -26,7 +26,7 @@ ROOT_PATH = Path(__file__).parent.parent.parent.resolve()
 def modules_and_ast(
     root_path: Path = ROOT_PATH,
     search_path: Path = Path(ROOT_PATH / "tests/resources/importer"),
-) -> Tuple[List[str], List[NamedModule]]:
+) -> tuple[list[str], list[NamedModule]]:
     return Parser(
         FileFilter(
             Config(
@@ -43,15 +43,15 @@ def modules_and_ast(
 
 
 @pytest.fixture(scope="module")
-def imports(modules_and_ast: Tuple[List[str], List[NamedModule]]) -> Sequence[Import]:
+def imports(modules_and_ast: tuple[list[str], list[NamedModule]]) -> Sequence[Import]:
     return ImportConverter().convert(modules_and_ast[1], "", set())
 
 
 @pytest.fixture(scope="module")
 def all_modules(
-    modules_and_ast: Tuple[List[str], List[NamedModule]],
-    imports: List[Import],
-) -> List[str]:
+    modules_and_ast: tuple[list[str], list[NamedModule]],
+    imports: list[Import],
+) -> list[str]:
     return ImporteeModuleCalculator(ROOT_PATH).calculate_importee_modules(
         imports,
         modules_and_ast[0],
@@ -59,7 +59,7 @@ def all_modules(
 
 
 @pytest.fixture(scope="module")
-def module_graph(all_modules: List[str], imports: List[Import]) -> NetworkxGraph:
+def module_graph(all_modules: list[str], imports: list[Import]) -> NetworkxGraph:
     return NetworkxGraph(all_modules, imports)
 
 

--- a/tests/integration/interesting_rules_for_tests.py
+++ b/tests/integration/interesting_rules_for_tests.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Dict, List, Optional
 
 import pytest
 from _pytest.mark import ParameterSet
@@ -1754,16 +1753,16 @@ partial_name_match_test_cases = [
 
 @dataclass
 class LayerRuleTestCase:
-    layers: Dict[str, List[str]]
+    layers: dict[str, list[str]]
     rule_setup: LayerRuleSetup
-    expected_error_message: Optional[str] = None
+    expected_error_message: str | None = None
 
 
 @dataclass
 class LayerRuleSingleModulePerLayerTestCase:
-    layers: Dict[str, str]
+    layers: dict[str, str]
     rule_setup: LayerRuleSetup
-    expected_error_message: Optional[str] = None
+    expected_error_message: str | None = None
 
 
 @dataclass
@@ -1771,7 +1770,7 @@ class LayerRuleSetup:
     behavior: str
     access_type: str
     importer: str
-    importee: List[str]
+    importee: list[str]
 
 
 PROJECT_ROOT = "flat_test_project_1"

--- a/tests/integration/test_level_limits.py
+++ b/tests/integration/test_level_limits.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from typing import Tuple
 
 import pytest
 from integration.interesting_rules_for_tests import (
@@ -131,7 +130,7 @@ def test_edges_correctly_calculated_for_level_2_module_path() -> None:
     )  # only parent-submodule edges # type: ignore
 
 
-def _not_inheritance_edge(edge: Tuple[str, str], graph: NetworkxGraph) -> bool:
+def _not_inheritance_edge(edge: tuple[str, str], graph: NetworkxGraph) -> bool:
     return not graph.parent_child_relationship(*edge)
 
 

--- a/tests/query_language/layered_architecture_rule/test_integration.py
+++ b/tests/query_language/layered_architecture_rule/test_integration.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import List, Mapping, Union
+from collections.abc import Mapping
 
 import pytest
 from integration.interesting_rules_for_tests import (
@@ -17,7 +17,7 @@ from pytestarch import EvaluableArchitecture, LayeredArchitecture, LayerRule
 
 
 def _get_layered_architecture(
-    layers: Mapping[str, Union[List[str], str]], module_regex: bool = False
+    layers: Mapping[str, list[str] | str], module_regex: bool = False
 ) -> LayeredArchitecture:
     arch = LayeredArchitecture()
 

--- a/tests/rule_assessment/test_RuleViolationMessageGenerator.py
+++ b/tests/rule_assessment/test_RuleViolationMessageGenerator.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Dict, List
-
 import pytest
 from integration.interesting_rules_for_tests import (
     FILE_A11,
@@ -203,7 +201,7 @@ message_content_test_cases = [
 )
 def test_rule_violation_message_content(
     generator: RuleViolationMessageGenerator,
-    violation: Dict[str, List[Dependency]],
+    violation: dict[str, list[Dependency]],
     expected_message: str,
 ) -> None:
     kwargs = _get_rule_violations_initialisation_dict(violation)
@@ -215,9 +213,9 @@ def test_rule_violation_message_content(
 
 
 def _get_rule_violations_initialisation_dict(
-    violation: Dict[str, List[Dependency]]
-) -> Dict[str, List[Dependency]]:
-    kwargs: Dict[str, List[Dependency]] = {
+    violation: dict[str, list[Dependency]]
+) -> dict[str, list[Dependency]]:
+    kwargs: dict[str, list[Dependency]] = {
         "should_violations": [],
         "should_only_violations_by_forbidden_import": [],
         "should_only_violations_by_no_import": [],
@@ -349,7 +347,7 @@ message_only_present_if_rule_violated_test_cases = [
 )
 def test_violated_message_only_present_if_rule_actually_violated(
     generator: RuleViolationMessageGenerator,
-    violation: Dict[str, List[Dependency]],
+    violation: dict[str, list[Dependency]],
 ) -> None:
     kwargs = _get_rule_violations_initialisation_dict(violation)
     violations = RuleViolations(
@@ -460,7 +458,7 @@ multiple_objects_in_one_message_test_cases = [
 )
 def test_multiple_rule_objects_combined_in_one_message(
     generator: RuleViolationMessageGenerator,
-    violation: Dict[str, List[Dependency]],
+    violation: dict[str, list[Dependency]],
     expected_message: str,
 ) -> None:
     kwargs = _get_rule_violations_initialisation_dict(violation)
@@ -601,9 +599,9 @@ multiple_objects_in_multiple_messages_test_cases = [
 )
 def test_multiple_rule_objects_in_multiple_message(
     generator: RuleViolationMessageGenerator,
-    violation: Dict[str, List[Dependency]],
+    violation: dict[str, list[Dependency]],
     expected_message_count: int,
-    expected_messages: List[str],
+    expected_messages: list[str],
 ) -> None:
     kwargs = _get_rule_violations_initialisation_dict(violation)
     violations = RuleViolations(**kwargs)  # type: ignore
@@ -652,8 +650,8 @@ forbidden_and_no_import_test_cases = [
     forbidden_and_no_import_test_cases,
 )
 def test_multiple_messages_if_forbidden_and_no_import_both_present(
-    violation: Dict[str, List[Dependency]],
-    expected_messages: List[str],
+    violation: dict[str, list[Dependency]],
+    expected_messages: list[str],
 ) -> None:
     kwargs = _get_rule_violations_initialisation_dict(violation)
     violations = RuleViolations(**kwargs)  # type: ignore

--- a/tests/rule_assessment/test_layer_rule_violation_detector.py
+++ b/tests/rule_assessment/test_layer_rule_violation_detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import pytest
 from rule_assessment.test_rule_violation_detector import (
@@ -97,22 +97,22 @@ LAYER_MAPPING = LayerMapping(
 
 @dataclass
 class RuleViolationDetectorTestCase:
-    behavior: Dict[str, Any]
-    expected_violation: Optional[str]
-    expected_violating_dependencies: List[Dependency]
-    explicitly_requested_dependencies: Optional[
-        ExplicitlyRequestedDependenciesByBaseModules
-    ]
-    not_explicitly_requested_dependencies: Optional[
-        NotExplicitlyRequestedDependenciesByBaseModule
-    ]
+    behavior: dict[str, Any]
+    expected_violation: str | None
+    expected_violating_dependencies: list[Dependency]
+    explicitly_requested_dependencies: (
+        ExplicitlyRequestedDependenciesByBaseModules | None
+    )
+    not_explicitly_requested_dependencies: (
+        NotExplicitlyRequestedDependenciesByBaseModule | None
+    )
     multiple_rule_objects: bool = False
 
 
 def _get_no_explicitly_requested_dependencies(
     multiple_rule_objects: bool = False,
 ) -> ExplicitlyRequestedDependenciesByBaseModules:
-    result: Dict[Tuple[Module, Module], List] = {
+    result: dict[tuple[Module, Module], list] = {
         (MODULE_1, MODULE_4): [],
         (MODULE_1, MODULE_5): [],
         (MODULE_1, MODULE_6): [],
@@ -140,7 +140,7 @@ def _get_no_explicitly_requested_dependencies(
 
 
 def _get_explicitly_requested_dependencies(
-    dependencies: List[Dependency], multiple_rule_objects: bool = False
+    dependencies: list[Dependency], multiple_rule_objects: bool = False
 ) -> ExplicitlyRequestedDependenciesByBaseModules:
     no_dependencies = _get_no_explicitly_requested_dependencies(multiple_rule_objects)
 
@@ -151,8 +151,8 @@ def _get_explicitly_requested_dependencies(
 
 
 def _get_all_violating_dependencies(
-    objects: Tuple[str, ...] = (LAYER_2,),
-) -> List[Dependency]:
+    objects: tuple[str, ...] = (LAYER_2,),
+) -> list[Dependency]:
     return [
         (Module(identifier=single_subject.name), Module(identifier=single_object.name))  # type: ignore
         for o in objects
@@ -168,7 +168,7 @@ def _get_no_not_explicitly_requested_dependencies() -> (
 
 
 def _get_not_explicitly_requested_dependencies(
-    dependencies: List[Dependency],
+    dependencies: list[Dependency],
 ) -> NotExplicitlyRequestedDependenciesByBaseModule:
     no_dependencies = _get_no_not_explicitly_requested_dependencies()
 

--- a/tests/rule_assessment/test_rule_matcher.py
+++ b/tests/rule_assessment/test_rule_matcher.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import fields
-from typing import List, Set
 
 import pytest
 
@@ -566,10 +565,10 @@ multiple_violations_test_cases = [
     multiple_violations_test_cases,
 )
 def test_multiple_violations_due_to_multiple_rule_objects(
-    imports: List[AbsoluteImport],
+    imports: list[AbsoluteImport],
     rule: Rule,
-    expected_violations: List[str],
-    expected_violating_dependencies: List[Set[Dependency]],
+    expected_violations: list[str],
+    expected_violating_dependencies: list[set[Dependency]],
 ) -> None:
     evaluable = EvaluableArchitectureGraph(NetworkxGraph(ALL_MODULES, imports))
     matcher = rule._prepare_rule_matcher()

--- a/tests/rule_assessment/test_rule_violation_detector.py
+++ b/tests/rule_assessment/test_rule_violation_detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Set
+from typing import Any
 
 import pytest
 
@@ -84,15 +84,15 @@ def get_module_requirement(**kwargs) -> ModuleRequirement:
 
 @dataclass
 class RuleViolationDetectorTestCase:
-    behavior: Dict[str, Any]
-    expected_violation: Optional[str]
-    expected_violating_dependencies: Set[Dependency]
-    explicitly_requested_dependencies: Optional[
-        ExplicitlyRequestedDependenciesByBaseModules
-    ]
-    not_explicitly_requested_dependencies: Optional[
-        NotExplicitlyRequestedDependenciesByBaseModule
-    ]
+    behavior: dict[str, Any]
+    expected_violation: str | None
+    expected_violating_dependencies: set[Dependency]
+    explicitly_requested_dependencies: (
+        ExplicitlyRequestedDependenciesByBaseModules | None
+    )
+    not_explicitly_requested_dependencies: (
+        NotExplicitlyRequestedDependenciesByBaseModule | None
+    )
 
 
 test_cases = [


### PR DESCRIPTION
Created using `ruff` to migrate annotations and imports.