### PR TITLE
export classes and methods via __all__

### DIFF
--- a/src/pytestarch/__init__.py
+++ b/src/pytestarch/__init__.py
@@ -1,13 +1,19 @@
-from pytestarch.eval_structure.evaluable_architecture import (  # noqa: F401
-    EvaluableArchitecture,
-)
-from pytestarch.query_language.rule import Rule  # noqa: F401
-from .pytestarch import get_evaluable_architecture  # noqa: F401 E401
-from .pytestarch import (  # noqa: F401 E401; noqa: F401 E401
-    get_evaluable_architecture_for_module_objects,
-)
-from pytestarch.query_language.layered_architecture_rule import (  # noqa: F401
+from pytestarch.eval_structure.evaluable_architecture import EvaluableArchitecture
+from pytestarch.query_language.rule import Rule
+from .pytestarch import get_evaluable_architecture
+from .pytestarch import get_evaluable_architecture_for_module_objects
+from pytestarch.query_language.layered_architecture_rule import (
     LayeredArchitecture,
     LayerRule,
 )
-from pytestarch.diagram_extension.diagram_rule import DiagramRule  # noqa: F401
+from pytestarch.diagram_extension.diagram_rule import DiagramRule
+
+__all__ = [
+    "DiagramRule",
+    "EvaluableArchitecture",
+    "get_evaluable_architecture",
+    "get_evaluable_architecture_for_module_objects",
+    "LayeredArchitecture",
+    "LayerRule",
+    "Rule",
+]


### PR DESCRIPTION
Export via `__all__`: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package

This also gets rid of the format-ignore comments for unused imports (because they are used now)