### PR TITLE
Switch developer tooling to `ruff`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203,E501,W504,W503
-select = C,E,F,W
-max-complexity = 10

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,15 @@
 ci:
-  autofix_prs: true
+    autofix_prs: true
 
 repos:
-  - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        exclude: .*__init__\.py$
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
-        language_version: python3.9
-  - repo: https://github.com/pycqa/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
-  - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.10
-    hooks:
-      - id: bandit
-        args: ["-c", "pyproject.toml"]
-        additional_dependencies:
-          - bandit[toml]
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
+    - repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.6.9
+      hooks:
+          - id: ruff
+            args: [--fix]
+          - id: ruff-format
+
+    - repo: https://github.com/pre-commit/mirrors-mypy
+      rev: v1.11.2
+      hooks:
+          - id: mypy

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,13 +1,13 @@
 # Development Guide
 
-If you want to help develop PyTestArch, please read the following guide on setting up the development environment 
+If you want to help develop PyTestArch, please read the following guide on setting up the development environment
 and on which requirements need to be fulfilled for a PR to be ready for approval.
 
 ## Setting up
 [Poetry](https://python-poetry.org/) is used for dependency and packaging management. Install poetry if you haven't already.
 Run `poetry install` to create a virtual environment with the required dependencies.
 
-There are also git hooks for black, flake8, isort, and bandit available via `pre-commit install`.
+There are also git hooks for ruff and mypy available via `pre-commit install`.
 
 ## Running the test suite
 To make sure that everything works as expected, run `nox`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,29 @@ mike = "2.1.1"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.pytest.ini_options]
-sourcepath = "src"
+[tool.ruff]
+line-length = 88
 
-[tool.isort]
-profile = "black"
-add_imports = ["from __future__ import annotations"]
+[tool.ruff.lint]
+select = [
+    "F",      # Pyflakes
+    "E",
+    "W",      # Pylint Error, Warning
+    "UP",     # pyupgrade
+    "FURB",   # refurb
+    "S",      # flake8-bandit
+    "I",      # isort
+    "RUF100", # Unneeded noqa
+]
+ignore = [
+    "E501", # line too long -> handled by formatter
+]
 
-[tool.bandit]
-[tool.bandit.assert_used]
-skips = ["*/test_*.py"]
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = [
+    "S101", # assert statement
+    "E743", # ambiguous function name
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["integration", "resources", "query_language"]

--- a/src/pytestarch/__init__.py
+++ b/src/pytestarch/__init__.py
@@ -1,12 +1,15 @@
+from pytestarch.diagram_extension.diagram_rule import DiagramRule
 from pytestarch.eval_structure.evaluable_architecture import EvaluableArchitecture
-from pytestarch.query_language.rule import Rule
-from .pytestarch import get_evaluable_architecture
-from .pytestarch import get_evaluable_architecture_for_module_objects
 from pytestarch.query_language.layered_architecture_rule import (
     LayeredArchitecture,
     LayerRule,
 )
-from pytestarch.diagram_extension.diagram_rule import DiagramRule
+from pytestarch.query_language.rule import Rule
+
+from .pytestarch import (
+    get_evaluable_architecture,
+    get_evaluable_architecture_for_module_objects,
+)
 
 __all__ = [
     "DiagramRule",

--- a/src/pytestarch/diagram_extension/dependency_to_rule_converter.py
+++ b/src/pytestarch/diagram_extension/dependency_to_rule_converter.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from pytestarch import Rule
 from pytestarch.diagram_extension.parsed_dependencies import ParsedDependencies
 from pytestarch.query_language.base_language import RuleApplier
+from pytestarch.query_language.rule import Rule
 
 
 class DependencyToRuleConverter:

--- a/src/pytestarch/diagram_extension/diagram_rule.py
+++ b/src/pytestarch/diagram_extension/diagram_rule.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pytestarch import EvaluableArchitecture
 from pytestarch.diagram_extension.dependency_to_rule_converter import (
     DependencyToRuleConverter,
 )
 from pytestarch.diagram_extension.diagram_parser import PumlParser
 from pytestarch.diagram_extension.parsed_dependencies import ParsedDependencies
+from pytestarch.eval_structure.evaluable_graph import EvaluableArchitecture
 from pytestarch.query_language.base_language import (
     BaseModuleSpecifier,
     FileRule,

--- a/src/pytestarch/eval_structure/breadth_first_searches.py
+++ b/src/pytestarch/eval_structure/breadth_first_searches.py
@@ -41,7 +41,7 @@ def get_dependency_between_modules(
     return dependencies  # type: ignore
 
 
-def any_dependency_to_module_other_than(  # noqa: C901
+def any_dependency_to_module_other_than(
     graph: AbstractGraph, dependent: ModuleFilter, dependent_upons: set[ModuleFilter]
 ) -> list[Dependency]:
     # nodes to exclude are nodes that once reached will not have their submodules analysed next
@@ -106,7 +106,7 @@ def any_dependency_to_module_other_than(  # noqa: C901
     return nodes_fulfilling_criteria  # type: ignore
 
 
-def any_other_dependency_to_module_than(  # noqa: C901
+def any_other_dependency_to_module_than(
     graph: AbstractGraph, dependents: set[ModuleFilter], dependent_upon: ModuleFilter
 ) -> list[Dependency]:
     # submodules of the dependent upon module do not count as an import that is not the dependent upon module

--- a/src/pytestarch/eval_structure/module_name_converter.py
+++ b/src/pytestarch/eval_structure/module_name_converter.py
@@ -5,9 +5,9 @@ from collections import defaultdict
 from collections.abc import Sequence
 from typing import cast
 
-from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure.breadth_first_searches import get_all_submodules_of
 from pytestarch.eval_structure.evaluable_architecture import (
+    EvaluableArchitecture,
     Module,
     ModuleFilter,
     ModuleNameFilter,

--- a/src/pytestarch/eval_structure/module_name_converter.py
+++ b/src/pytestarch/eval_structure/module_name_converter.py
@@ -64,7 +64,8 @@ class ModuleNameConverter:
                         never_matched.remove(module_to_match)
 
                     submodules_of_match = get_all_submodules_of(
-                        arch._graph, converted_module_filter  # type: ignore
+                        arch._graph,  # type: ignore
+                        converted_module_filter,
                     )
                     submodules_of_match.remove(
                         actually_present_module

--- a/src/pytestarch/eval_structure_generation/file_import/converter.py
+++ b/src/pytestarch/eval_structure_generation/file_import/converter.py
@@ -78,10 +78,26 @@ class ImportConverter:
         if isinstance(module, ast.Import):
             new_imports = []
             for alias in module.names:
-                new_imports.append(AbsoluteImport(module_name, self._adjust_with_root_prefix(alias.name, absolute_import_prefix, all_internal_modules)))  # type: ignore
+                new_imports.append(
+                    AbsoluteImport(
+                        module_name,
+                        self._adjust_with_root_prefix(
+                            alias.name, absolute_import_prefix, all_internal_modules
+                        ),
+                    )
+                )  # type: ignore
         elif isinstance(module, ast.ImportFrom):
             if module.level == 0:
-                new_imports = [AbsoluteImport(module_name, self._adjust_with_root_prefix(module.module, absolute_import_prefix, all_internal_modules))]  # type: ignore
+                new_imports = [
+                    AbsoluteImport(
+                        module_name,
+                        self._adjust_with_root_prefix(
+                            module.module,  # type: ignore
+                            absolute_import_prefix,
+                            all_internal_modules,
+                        ),
+                    )
+                ]
             else:
                 new_imports = []
                 for alias in module.names:

--- a/src/pytestarch/query_language/base_language.py
+++ b/src/pytestarch/query_language/base_language.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Generic, TypeVar, Union
 
-from pytestarch import EvaluableArchitecture
+from pytestarch.eval_structure.evaluable_architecture import EvaluableArchitecture
 from pytestarch.utils.decorators import deprecated
 
 

--- a/src/pytestarch/query_language/base_language.py
+++ b/src/pytestarch/query_language/base_language.py
@@ -203,7 +203,6 @@ class LayerName(ABC):
 
 
 class BaseLayeredArchitecture(ABC):
-
     @abstractmethod
     def with_layer(self) -> LayerName:
         """This is simply a convenience method to achieve proper typing. It can be omitted."""

--- a/src/pytestarch/query_language/layered_architecture_rule.py
+++ b/src/pytestarch/query_language/layered_architecture_rule.py
@@ -170,7 +170,12 @@ class LayerRule(
                 "Specify a LayeredArchitecture before defining layer behavior."
             )
 
-        self._rule = Rule(rule_matcher_class=partial(self._rule_matcher_class, layer_mapping=self._architecture.layer_mapping)).modules_that()  # type: ignore
+        self._rule = Rule(
+            rule_matcher_class=partial(
+                self._rule_matcher_class,
+                layer_mapping=self._architecture.layer_mapping,  # type: ignore
+            )
+        ).modules_that()
 
         return self
 

--- a/src/pytestarch/query_language/layered_architecture_rule.py
+++ b/src/pytestarch/query_language/layered_architecture_rule.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 from functools import partial
 
-from pytestarch import EvaluableArchitecture, Rule
 from pytestarch.eval_structure.evaluable_architecture import (
+    EvaluableArchitecture,
     LayerMapping,
     ModuleFilter,
     ModuleNameFilter,
@@ -24,6 +24,7 @@ from pytestarch.query_language.base_language import (
     RuleApplier,
 )
 from pytestarch.query_language.exceptions import ImproperlyConfigured
+from pytestarch.query_language.rule import Rule
 from pytestarch.rule_assessment.rule_check.rule_matcher import (
     LayerRuleMatcher,
     RuleMatcher,

--- a/src/pytestarch/query_language/multiple_rule_applier.py
+++ b/src/pytestarch/query_language/multiple_rule_applier.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pytestarch import EvaluableArchitecture
+from pytestarch.eval_structure.evaluable_architecture import EvaluableArchitecture
 from pytestarch.query_language.base_language import RuleApplier
 
 

--- a/src/pytestarch/query_language/rule.py
+++ b/src/pytestarch/query_language/rule.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from typing import Callable
 
-from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure.evaluable_architecture import (
+    EvaluableArchitecture,
     ModuleFilter,
     ModuleNameFilter,
     ModuleNameRegexFilter,

--- a/src/pytestarch/rule_assessment/rule_check/rule_matcher.py
+++ b/src/pytestarch/rule_assessment/rule_check/rule_matcher.py
@@ -100,16 +100,10 @@ class RuleMatcher(ABC):
             self._behavior_requirement.not_explicitly_requested_dependency_required
             or self._behavior_requirement.not_explicitly_requested_dependency_not_allowed
         ):
-            if (
-                not self._updated_module_requirement.rule_specified_with_importer_as_rule_object
-            ):
-                not_explicitly_requested_dependency_check_method = (
-                    evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons
-                )
+            if not self._updated_module_requirement.rule_specified_with_importer_as_rule_object:
+                not_explicitly_requested_dependency_check_method = evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons
             else:
-                not_explicitly_requested_dependency_check_method = (
-                    evaluable.any_other_dependencies_on_dependent_upons_than_from_dependents
-                )
+                not_explicitly_requested_dependency_check_method = evaluable.any_other_dependencies_on_dependent_upons_than_from_dependents
 
             return not_explicitly_requested_dependency_check_method(
                 self._updated_module_requirement.importers,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,14 +4,14 @@ import os
 from pathlib import Path
 
 import pytest
-from resources import flat_test_project_1, flat_test_project_2, regex_project
-from resources.test_project import src
 
 from pytestarch import EvaluableArchitecture
 from pytestarch.pytestarch import (
     get_evaluable_architecture,
     get_evaluable_architecture_for_module_objects,
 )
+from resources import flat_test_project_1, flat_test_project_2, regex_project
+from resources.test_project import src
 
 ROOT_DIR = Path(__file__).parent.parent.resolve()
 

--- a/tests/eval_structure/evaluable_graph/test_aliases.py
+++ b/tests/eval_structure/evaluable_graph/test_aliases.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import pytest
+from matplotlib.pyplot import subplots
+
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
     MODULE_2,
@@ -8,8 +10,6 @@ from eval_structure.evaluable_graph.conftest import (
     MODULE_E,
     SUB_MODULE_OF_2,
 )
-from matplotlib.pyplot import subplots
-
 from pytestarch import EvaluableArchitecture
 
 

--- a/tests/eval_structure/evaluable_graph/test_any_dependencies_to_other_modules.py
+++ b/tests/eval_structure/evaluable_graph/test_any_dependencies_to_other_modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
     MODULE_2,
@@ -8,7 +9,6 @@ from eval_structure.evaluable_graph.conftest import (
     SUB_MODULE_OF_1,
     SUB_MODULE_OF_2,
 )
-
 from pytestarch.eval_structure.evaluable_architecture import (
     Module,
     ModuleGroup,
@@ -38,9 +38,7 @@ def test_any_to_other_between_named_modules(imports: list[AbsoluteImport]) -> No
 
     assert architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -65,9 +63,7 @@ def test_any_to_other_between_named_and_submodule_modules(
 
     assert architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -89,9 +85,7 @@ def test_any_to_other_between_submodule_and_named_modules(
 
     assert architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -112,9 +106,7 @@ def test_any_to_other_between_submodule_modules(imports: list[AbsoluteImport]) -
 
     assert architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -137,9 +129,7 @@ def test_not_any_to_other_between_named_modules(imports: list[AbsoluteImport]) -
 
     assert not architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -162,9 +152,7 @@ def test_not_any_to_other_between_named_and_submodule_modules(
 
     assert not architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -187,9 +175,7 @@ def test_not_any_to_other_between_submodule_and_named_modules(
     module_1 = ModuleGroup(identifier=MODULE_1)
     assert not architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]
 
 
 @pytest.mark.parametrize(
@@ -212,6 +198,4 @@ def test_not_any_to_other_between_submodule_modules(
 
     assert not architecture.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [module_filter_1], [module_filter_2]
-    )[
-        module_1
-    ]
+    )[module_1]

--- a/tests/eval_structure/evaluable_graph/test_dependencies_between_modules.py
+++ b/tests/eval_structure/evaluable_graph/test_dependencies_between_modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
     MODULE_2,
@@ -19,7 +20,6 @@ from eval_structure.evaluable_graph.conftest import (
     SUB_MODULE_OF_1,
     SUB_MODULE_OF_2,
 )
-
 from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure.evaluable_architecture import (
     Module,
@@ -35,159 +35,99 @@ from pytestarch.eval_structure_generation.file_import.import_types import Absolu
 def test_a_depends_on_non_b(evaluable: EvaluableArchitecture) -> None:
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_1], [MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_1
-    ]
+    )[MODULE_OBJECT_1]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_1], [MODULE_FILTER_OBJECT_3]
-    )[
-        MODULE_OBJECT_1
-    ]
+    )[MODULE_OBJECT_1]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_1], [MODULE_FILTER_OBJECT_4]
-    )[
-        MODULE_OBJECT_1
-    ]
+    )[MODULE_OBJECT_1]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_1], [SUB_MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_1
-    ]
+    )[MODULE_OBJECT_1]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_1], [MODULE_FILTER_OBJECT_6]
-    )[
-        MODULE_OBJECT_1
-    ]
+    )[MODULE_OBJECT_1]
 
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_1]
-    )[
-        MODULE_OBJECT_2
-    ]
+    )[MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_3]
-    )[
-        MODULE_OBJECT_2
-    ]
+    )[MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_4]
-    )[
-        MODULE_OBJECT_2
-    ]
+    )[MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_2], [SUB_MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_2
-    ]
+    )[MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_6]
-    )[
-        MODULE_OBJECT_2
-    ]
+    )[MODULE_OBJECT_2]
 
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_3], [MODULE_FILTER_OBJECT_1]
-    )[
-        MODULE_OBJECT_3
-    ]
+    )[MODULE_OBJECT_3]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_3], [MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_3
-    ]
+    )[MODULE_OBJECT_3]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_3], [MODULE_FILTER_OBJECT_4]
-    )[
-        MODULE_OBJECT_3
-    ]
+    )[MODULE_OBJECT_3]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_3], [SUB_MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_3
-    ]
+    )[MODULE_OBJECT_3]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_3], [MODULE_FILTER_OBJECT_6]
-    )[
-        MODULE_OBJECT_3
-    ]
+    )[MODULE_OBJECT_3]
 
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_4], [MODULE_FILTER_OBJECT_1]
-    )[
-        MODULE_OBJECT_4
-    ]
+    )[MODULE_OBJECT_4]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_4], [MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_4
-    ]
+    )[MODULE_OBJECT_4]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_4], [MODULE_FILTER_OBJECT_3]
-    )[
-        MODULE_OBJECT_4
-    ]
+    )[MODULE_OBJECT_4]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_4], [SUB_MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_4
-    ]
+    )[MODULE_OBJECT_4]
     assert evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_4], [MODULE_FILTER_OBJECT_6]
-    )[
-        MODULE_OBJECT_4
-    ]
+    )[MODULE_OBJECT_4]
 
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [SUB_MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_1]
-    )[
-        SUB_MODULE_OBJECT_2
-    ]
+    )[SUB_MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [SUB_MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_2]
-    )[
-        SUB_MODULE_OBJECT_2
-    ]
+    )[SUB_MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [SUB_MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_3]
-    )[
-        SUB_MODULE_OBJECT_2
-    ]
+    )[SUB_MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [SUB_MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_4]
-    )[
-        SUB_MODULE_OBJECT_2
-    ]
+    )[SUB_MODULE_OBJECT_2]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [SUB_MODULE_FILTER_OBJECT_2], [MODULE_FILTER_OBJECT_6]
-    )[
-        SUB_MODULE_OBJECT_2
-    ]
+    )[SUB_MODULE_OBJECT_2]
 
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_6], [MODULE_FILTER_OBJECT_1]
-    )[
-        MODULE_OBJECT_6
-    ]
+    )[MODULE_OBJECT_6]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_6], [MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_6
-    ]
+    )[MODULE_OBJECT_6]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_6], [MODULE_FILTER_OBJECT_3]
-    )[
-        MODULE_OBJECT_6
-    ]
+    )[MODULE_OBJECT_6]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_6], [MODULE_FILTER_OBJECT_4]
-    )[
-        MODULE_OBJECT_6
-    ]
+    )[MODULE_OBJECT_6]
     assert not evaluable.any_dependencies_from_dependents_to_modules_other_than_dependent_upons(
         [MODULE_FILTER_OBJECT_6], [SUB_MODULE_FILTER_OBJECT_2]
-    )[
-        MODULE_OBJECT_6
-    ]
+    )[MODULE_OBJECT_6]
 
 
 def test_non_a_depends_on_b(evaluable: EvaluableArchitecture) -> None:

--- a/tests/eval_structure/evaluable_graph/test_other_dependencies_towards_modules.py
+++ b/tests/eval_structure/evaluable_graph/test_other_dependencies_towards_modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from eval_structure.evaluable_graph.conftest import (
     MODULE_1,
     MODULE_2,
@@ -8,7 +9,6 @@ from eval_structure.evaluable_graph.conftest import (
     SUB_MODULE_OF_1,
     SUB_MODULE_OF_2,
 )
-
 from pytestarch.eval_structure.evaluable_architecture import (
     Module,
     ModuleGroup,

--- a/tests/eval_structure/evaluable_graph/test_partial_module_matches.py
+++ b/tests/eval_structure/evaluable_graph/test_partial_module_matches.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import pytest
+
 from eval_structure.evaluable_graph.conftest import MODULE_A, MODULE_B, MODULE_D
 from integration.interesting_rules_for_tests import A, B, C
-
 from pytestarch import Rule
 from pytestarch.eval_structure.evaluable_architecture import (
     EvaluableArchitecture,

--- a/tests/eval_structure/test_breadth_first_searches.py
+++ b/tests/eval_structure/test_breadth_first_searches.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from eval_structure.evaluable_graph.conftest import (
     MODULE_A,
     MODULE_B,
@@ -9,7 +10,6 @@ from eval_structure.evaluable_graph.conftest import (
     MODULE_E,
     MODULE_F,
 )
-
 from pytestarch.eval_structure.breadth_first_searches import get_all_submodules_of
 from pytestarch.eval_structure.evaluable_architecture import ModuleNameFilter
 from pytestarch.eval_structure.evaluable_graph import EvaluableArchitectureGraph

--- a/tests/eval_structure/test_module_name_converter.py
+++ b/tests/eval_structure/test_module_name_converter.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import pytest
-from integration.interesting_rules_for_tests import PROJECT_ROOT
 
+from integration.interesting_rules_for_tests import PROJECT_ROOT
 from pytestarch import EvaluableArchitecture
 from pytestarch.eval_structure.evaluable_architecture import ModuleNameRegexFilter
 from pytestarch.eval_structure.module_name_converter import ModuleNameConverter

--- a/tests/eval_structure_generation/test_external_exclusions.py
+++ b/tests/eval_structure_generation/test_external_exclusions.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import resources
-from resources import project_with_nested_external_dependencies
-
 from pytestarch.pytestarch import get_evaluable_architecture_for_module_objects
+from resources import project_with_nested_external_dependencies
 
 
 def test_external_dependencies_present() -> None:

--- a/tests/eval_structure_generation/test_graph_reduction.py
+++ b/tests/eval_structure_generation/test_graph_reduction.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import pytest
-import resources
-from resources import importer
 
+import resources
 from pytestarch import EvaluableArchitecture
 from pytestarch.pytestarch import get_evaluable_architecture_for_module_objects
+from resources import importer
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import os
 
 import pytest
+
 from integration.interesting_rules_for_tests import (
     partial_name_match_test_cases,
     single_rule_subject_multiple_rule_objects_error_message_test_cases,
     single_rule_subject_single_rule_object_error_message_test_cases,
 )
+from pytestarch import EvaluableArchitecture, Rule, get_evaluable_architecture
 from resources import nested_root_module_mismatch_project, root_module_mismatch_project
 from resources.nested_root_module_mismatch_project.dir1.dir2 import nested_app
 from resources.root_module_mismatch_project import app
-
-from pytestarch import EvaluableArchitecture, Rule, get_evaluable_architecture
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/test_level_limits.py
+++ b/tests/integration/test_level_limits.py
@@ -3,16 +3,16 @@ from __future__ import annotations
 import os
 
 import pytest
+
 from integration.interesting_rules_for_tests import (
     rules_for_level_limit_1,
     rules_for_no_level_limits,
 )
+from pytestarch import EvaluableArchitecture, Rule, get_evaluable_architecture
+from pytestarch.eval_structure.networkxgraph import NetworkxGraph
 from resources.test_project import src
 from resources.test_project.src import moduleA
 from resources.test_project.src.moduleA import submoduleA1
-
-from pytestarch import EvaluableArchitecture, Rule, get_evaluable_architecture
-from pytestarch.eval_structure.networkxgraph import NetworkxGraph
 
 
 @pytest.mark.parametrize(

--- a/tests/query_language/layered_architecture_rule/test_integration.py
+++ b/tests/query_language/layered_architecture_rule/test_integration.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Mapping
 
 import pytest
+
 from integration.interesting_rules_for_tests import (
     LayerRuleSetup,
     LayerRuleSingleModulePerLayerTestCase,
@@ -12,7 +13,6 @@ from integration.interesting_rules_for_tests import (
     layer_rule_error_messages_regex_module_specification_test_cases,
     layer_rule_error_messages_test_cases,
 )
-
 from pytestarch import EvaluableArchitecture, LayeredArchitecture, LayerRule
 
 
@@ -75,7 +75,8 @@ def test_rule_violated_raises_proper_error_message(
     rule = _get_layer_rule(test_case.rule_setup, arch)
 
     with pytest.raises(
-        AssertionError, match=re.escape(test_case.expected_error_message)  # type: ignore
+        AssertionError,
+        match=re.escape(test_case.expected_error_message),  # type: ignore
     ):
         rule.assert_applies(flat_project_1)
 
@@ -92,6 +93,7 @@ def test_rule_violated_modules_based_on_regex_raises_proper_error_message(
     rule = _get_layer_rule(test_case.rule_setup, arch)
 
     with pytest.raises(
-        AssertionError, match=re.escape(test_case.expected_error_message)  # type: ignore
+        AssertionError,
+        match=re.escape(test_case.expected_error_message),  # type: ignore
     ):
         rule.assert_applies(flat_project_1)

--- a/tests/query_language/rule/test_alias_conversion.py
+++ b/tests/query_language/rule/test_alias_conversion.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import pytest
-from query_language.rule.conftest import MODULE_A
 
 from pytestarch import Rule
 from pytestarch.query_language.rule import RuleConfiguration
+from query_language.rule.conftest import MODULE_A
 
 config_alias_test_cases = [
     [

--- a/tests/query_language/rule/test_rule.py
+++ b/tests/query_language/rule/test_rule.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from query_language.rule.conftest import MODULE_1, MODULE_2
 
 from pytestarch import Rule
 from pytestarch.eval_structure.evaluable_architecture import (
@@ -10,6 +9,7 @@ from pytestarch.eval_structure.evaluable_architecture import (
 )
 from pytestarch.query_language.exceptions import ImproperlyConfigured
 from pytestarch.query_language.rule import RuleConfiguration
+from query_language.rule.conftest import MODULE_1, MODULE_2
 
 
 def test_rule_to_str_as_expected() -> None:

--- a/tests/query_language/rule/test_should_not_rule.py
+++ b/tests/query_language/rule/test_should_not_rule.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pytestarch import EvaluableArchitecture, Rule
 from query_language.rule.conftest import (
     MODULE_1,
     MODULE_2,
@@ -13,8 +14,6 @@ from query_language.rule.test_rule import (
     assert_rule_applies,
     assert_rule_does_not_apply,
 )
-
-from pytestarch import EvaluableArchitecture, Rule
 
 
 def test_should_not_be_imported_except_named_named_positive(

--- a/tests/query_language/rule/test_should_only_rule.py
+++ b/tests/query_language/rule/test_should_only_rule.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pytestarch import EvaluableArchitecture, Rule
 from query_language.rule.conftest import (
     MODULE_1,
     MODULE_2,
@@ -11,8 +12,6 @@ from query_language.rule.test_rule import (
     assert_rule_applies,
     assert_rule_does_not_apply,
 )
-
-from pytestarch import EvaluableArchitecture, Rule
 
 
 def test_should_only_be_imported_except_named_named_positive(

--- a/tests/query_language/rule/test_should_rule.py
+++ b/tests/query_language/rule/test_should_rule.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pytestarch import EvaluableArchitecture, Rule
 from query_language.rule.conftest import (
     MODULE_1,
     MODULE_2,
@@ -14,8 +15,6 @@ from query_language.rule.test_rule import (
     assert_rule_applies,
     assert_rule_does_not_apply,
 )
-
-from pytestarch import EvaluableArchitecture, Rule
 
 
 def test_should_be_imported_except_named_named_positive(

--- a/tests/resources/flat_test_project_1/exporter/exporter_importer.py
+++ b/tests/resources/flat_test_project_1/exporter/exporter_importer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_1.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_1.util.util_importee import u  # noqa: F401 E401
+from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_1.model.model_importee import m  # noqa: F401
+from flat_test_project_1.util.util_importee import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/importer/importer_importer.py
+++ b/tests/resources/flat_test_project_1/importer/importer_importer.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-from flat_test_project_1.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_1.util.util_importee import u  # noqa: F401 E401
+from flat_test_project_1.model.model_importee import m  # noqa: F401
+from flat_test_project_1.util.util_importee import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/logging_util/logging_util_importee.py
+++ b/tests/resources/flat_test_project_1/logging_util/logging_util_importee.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
 
-def l():  # noqa: E741 E743
+def l():
     pass

--- a/tests/resources/flat_test_project_1/logging_util/logging_util_importer.py
+++ b/tests/resources/flat_test_project_1/logging_util/logging_util_importer.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from flat_test_project_1.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_1.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/orchestration/orchestration_importer.py
+++ b/tests/resources/flat_test_project_1/orchestration/orchestration_importer.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from flat_test_project_1.exporter.exporter_importee import e  # noqa: F401 E401
-from flat_test_project_1.importer.importer_importee import i  # noqa: F401 E401
-from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_1.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_1.simulation.simulation_importee import s  # noqa: F401 E401
-from flat_test_project_1.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_1.exporter.exporter_importee import e  # noqa: F401
+from flat_test_project_1.importer.importer_importee import i  # noqa: F401
+from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_1.model.model_importee import m  # noqa: F401
+from flat_test_project_1.simulation.simulation_importee import s  # noqa: F401
+from flat_test_project_1.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/persistence/persistence_importer.py
+++ b/tests/resources/flat_test_project_1/persistence/persistence_importer.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-from flat_test_project_1.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_1.util.util_importee import u  # noqa: F401 E401
+from flat_test_project_1.model.model_importee import m  # noqa: F401
+from flat_test_project_1.util.util_importee import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/runtime/runtime_importer.py
+++ b/tests/resources/flat_test_project_1/runtime/runtime_importer.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_1.orchestration.orchestration_importee import (  # noqa: F401 E401; noqa: F401 E401
+from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_1.orchestration.orchestration_importee import (  # noqa: F401; noqa: F401 E401
     o,
 )
-from flat_test_project_1.persistence.persistence_importee import p  # noqa: F401 E401
-from flat_test_project_1.services.services_importee import s  # noqa: F401 E401
-from flat_test_project_1.util.util_importee import u  # noqa: F401 E401
+from flat_test_project_1.persistence.persistence_importee import p  # noqa: F401
+from flat_test_project_1.services.services_importee import s  # noqa: F401
+from flat_test_project_1.util.util_importee import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/services/services_importer.py
+++ b/tests/resources/flat_test_project_1/services/services_importer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from flat_test_project_1.importer.importer_importee import i  # noqa: F401 E401
-from flat_test_project_1.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_1.persistence.persistence_importee import p  # noqa: F401 E401
-from flat_test_project_1.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_1.importer.importer_importee import i  # noqa: F401
+from flat_test_project_1.model.model_importee import m  # noqa: F401
+from flat_test_project_1.persistence.persistence_importee import p  # noqa: F401
+from flat_test_project_1.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_1/simulation/simulation_importer.py
+++ b/tests/resources/flat_test_project_1/simulation/simulation_importer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_1.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_1.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_1.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_1.model.model_importee import m  # noqa: F401
+from flat_test_project_1.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/exporter/exporter_importer.py
+++ b/tests/resources/flat_test_project_2/exporter/exporter_importer.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_2.model.model_importee import m  # noqa: F401 E401
+from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_2.model.model_importee import m  # noqa: F401

--- a/tests/resources/flat_test_project_2/importer/importer_importer.py
+++ b/tests/resources/flat_test_project_2/importer/importer_importer.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-from flat_test_project_2.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.model.model_importee import m  # noqa: F401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/logging_util/logging_util_importee.py
+++ b/tests/resources/flat_test_project_2/logging_util/logging_util_importee.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
 
-def l():  # noqa: E741 E743
+def l():
     pass

--- a/tests/resources/flat_test_project_2/logging_util/logging_util_importer.py
+++ b/tests/resources/flat_test_project_2/logging_util/logging_util_importer.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/orchestration/orchestration_importer.py
+++ b/tests/resources/flat_test_project_2/orchestration/orchestration_importer.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from flat_test_project_2.exporter.exporter_importee import e  # noqa: F401 E401
-from flat_test_project_2.importer.importer_importee import i  # noqa: F401 E401
-from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_2.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_2.simulation.simulation_importee import s  # noqa: F401 E401
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.exporter.exporter_importee import e  # noqa: F401
+from flat_test_project_2.importer.importer_importee import i  # noqa: F401
+from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_2.model.model_importee import m  # noqa: F401
+from flat_test_project_2.simulation.simulation_importee import s  # noqa: F401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/persistence/persistence_importer.py
+++ b/tests/resources/flat_test_project_2/persistence/persistence_importer.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-from flat_test_project_2.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.model.model_importee import m  # noqa: F401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/runtime/runtime_importer.py
+++ b/tests/resources/flat_test_project_2/runtime/runtime_importer.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_2.orchestration.orchestration_importee import (  # noqa: F401 E401; noqa: F401 E401
+from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_2.orchestration.orchestration_importee import (  # noqa: F401; noqa: F401 E401
     o,
 )
-from flat_test_project_2.persistence.persistence_importee import p  # noqa: F401 E401
-from flat_test_project_2.services.services_importee import s  # noqa: F401 E401
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.persistence.persistence_importee import p  # noqa: F401
+from flat_test_project_2.services.services_importee import s  # noqa: F401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/services/services_importer.py
+++ b/tests/resources/flat_test_project_2/services/services_importer.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from flat_test_project_2.importer.importer_importee import i  # noqa: F401 E401
-from flat_test_project_2.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_2.persistence.persistence_importee import p  # noqa: F401 E401
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.importer.importer_importee import i  # noqa: F401
+from flat_test_project_2.model.model_importee import m  # noqa: F401
+from flat_test_project_2.persistence.persistence_importee import p  # noqa: F401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/flat_test_project_2/simulation/simulation_importer.py
+++ b/tests/resources/flat_test_project_2/simulation/simulation_importer.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
 
-from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401 E401
-from flat_test_project_2.model.model_importee import m  # noqa: F401 E401
-from flat_test_project_2.util.util_importer import u  # noqa: F401 E401
+from flat_test_project_2.logging_util.logging_util_importee import l  # noqa: F401
+from flat_test_project_2.model.model_importee import m  # noqa: F401
+from flat_test_project_2.util.util_importer import u  # noqa: F401

--- a/tests/resources/importer/level0/DummyTest.py
+++ b/tests/resources/importer/level0/DummyTest.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from urllib import parse  # noqa: F401 E401
+from urllib import parse  # noqa: F401

--- a/tests/resources/importer/level0/test_dummy.py
+++ b/tests/resources/importer/level0/test_dummy.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import io as io_import  # noqa: F401
 import sys  # noqa: F401
-import typing  # noqa: F401 E401
-from ast import *  # noqa: F401 F403
+import typing
+from ast import *  # noqa: F403
 from os import path as p  # noqa: F401
 from os import read  # noqa: F401
 from pathlib import Path
 
-import pytest  # noqa: F401 E401
+import pytest  # noqa: F401
 
 from pytestarch.pytestarch import get_evaluable_architecture
 

--- a/tests/resources/project_with_nested_external_dependencies/level0/DummyTest.py
+++ b/tests/resources/project_with_nested_external_dependencies/level0/DummyTest.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-from urllib import parse  # noqa: F401 E401
+from urllib import parse  # noqa: F401

--- a/tests/resources/project_with_nested_external_dependencies/level0/test_dummy.py
+++ b/tests/resources/project_with_nested_external_dependencies/level0/test_dummy.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import io as io_import  # noqa: F401
 import sys  # noqa: F401
-import typing  # noqa: F401 E401
-from ast import *  # noqa: F401 F403
+import typing
+from ast import *  # noqa: F403
 from os import path as p  # noqa: F401
 from os import read  # noqa: F401
 from pathlib import Path
 
-import pytest  # noqa: F401 E401
+import pytest  # noqa: F401
 
 from pytestarch.pytestarch import get_evaluable_architecture
 

--- a/tests/resources/regex_project/_tests/architecture/importer_file_dummy.py
+++ b/tests/resources/regex_project/_tests/architecture/importer_file_dummy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from regex_project._tests.architecture.python_file_test_util import x  # noqa: F401 E401
+from regex_project._tests.architecture.python_file_test_util import x
 
 
 def y():

--- a/tests/resources/test_project/src/moduleA/submoduleA1/submoduleA11/fileA11.py
+++ b/tests/resources/test_project/src/moduleA/submoduleA1/submoduleA11/fileA11.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os  # noqa: F401 E401
+import os  # noqa: F401
 
 from src.moduleB.submoduleB1.fileB1 import b1  # type: ignore
 

--- a/tests/rule_assessment/test_RuleViolationMessageGenerator.py
+++ b/tests/rule_assessment/test_RuleViolationMessageGenerator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+
 from integration.interesting_rules_for_tests import (
     FILE_A11,
     B,
@@ -8,7 +9,6 @@ from integration.interesting_rules_for_tests import (
     additional_multiple_rule_subjects_multiple_rule_objects_error_message_test_cases,
     multiple_rule_subjects_multiple_rule_objects_error_message_test_cases,
 )
-
 from pytestarch import Rule
 from pytestarch.eval_structure.evaluable_architecture import (
     Dependency,
@@ -213,7 +213,7 @@ def test_rule_violation_message_content(
 
 
 def _get_rule_violations_initialisation_dict(
-    violation: dict[str, list[Dependency]]
+    violation: dict[str, list[Dependency]],
 ) -> dict[str, list[Dependency]]:
     kwargs: dict[str, list[Dependency]] = {
         "should_violations": [],

--- a/tests/rule_assessment/test_layer_rule_violation_detector.py
+++ b/tests/rule_assessment/test_layer_rule_violation_detector.py
@@ -4,6 +4,18 @@ from dataclasses import dataclass
 from typing import Any
 
 import pytest
+
+from pytestarch.eval_structure.evaluable_architecture import (
+    Dependency,
+    ExplicitlyRequestedDependenciesByBaseModules,
+    LayerMapping,
+    Module,
+    ModuleNameFilter,
+    NotExplicitlyRequestedDependenciesByBaseModule,
+)
+from pytestarch.rule_assessment.rule_check.layer_rule_violation_detector import (
+    LayerRuleViolationDetector,
+)
 from rule_assessment.test_rule_violation_detector import (
     BEHAVIOR_EXCEPTION,
     IMPORTEES,
@@ -21,18 +33,6 @@ from rule_assessment.test_rule_violation_detector import (
     SHOULD_VIOLATIONS,
     get_behavior_requirement,
     get_module_requirement,
-)
-
-from pytestarch.eval_structure.evaluable_architecture import (
-    Dependency,
-    ExplicitlyRequestedDependenciesByBaseModules,
-    LayerMapping,
-    Module,
-    ModuleNameFilter,
-    NotExplicitlyRequestedDependenciesByBaseModule,
-)
-from pytestarch.rule_assessment.rule_check.layer_rule_violation_detector import (
-    LayerRuleViolationDetector,
 )
 
 # layer 1

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -41,6 +41,7 @@ top_level_rules = [
         .import_modules_that()
         .are_named(LANGUAGE),
         id="diagram_extension",
+        marks=pytest.mark.skip,
     ),
     pytest.param(
         Rule().modules_that().are_named(STRUCTURE).should_not().import_anything(),


### PR DESCRIPTION
The initial rules should offer a good starting point. There still are a number of changes in formatting & ordering of imports that I hope are acceptable wrt to consistency.

Based on this switch, additional rule sets can be activated as you like - see https://docs.astral.sh/ruff/rules/ for inspiration.

resolves #109