### PR TITLE
Feature: Feedback for unknown modules

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,7 @@ This project uses semantic versioning and follows [keep a changelog](https://kee
 - Straightforward error message when using wildcards in `are_named` rules.
 - Typo in docstring of `get_evaluable_architecture(..)`.
 - Module filter uses regex when activated instead of only if last module.
+- Descriptive error message with actionable guidance when a queried module is not present in the dependency graph.
 
 ## 4.0.1 -- 2025-08-08
 ### Fixed

--- a/docs/features/general.md
+++ b/docs/features/general.md
@@ -114,6 +114,13 @@ node names "os" at all.
 This has been achieved by setting the `exclude_external_libraries` flag in the `get_evaluable_architecture` function. All modules that 
 not located hierarchically below the root path, in this case "test_project", will be excluded from the graph.
 
+### Module not found in graph
+If a rule references a module that does not appear in the dependency graph, PyTestArch raises a `NotInGraph` error with an actionable message. Common causes are:
+
+- **External library excluded**: the module belongs to a third-party package and `exclude_external_libraries=True` (the default). Pass `exclude_external_libraries=False` to `get_evaluable_architecture()` to include it.
+- **Module never imported**: the module exists but is not imported by any code under the scanned `module_path`, so it was never added to the graph.
+- **Misspelled module name**: module names in rules must match the fully qualified import name (e.g. `mypackage.service`, not `service`).
+
 
 <br>
 # Additional Notes

--- a/docs/features/general.md
+++ b/docs/features/general.md
@@ -115,7 +115,7 @@ This has been achieved by setting the `exclude_external_libraries` flag in the `
 not located hierarchically below the root path, in this case "test_project", will be excluded from the graph.
 
 ### Module not found in graph
-If a rule references a module that does not appear in the dependency graph, PyTestArch raises a `NotInGraph` error with an actionable message. Common causes are:
+If a rule references a module that does not appear in the dependency graph, PyTestArch raises a `ModuleUnknown` error with an actionable message. Common causes are:
 
 - **External library excluded**: the module belongs to a third-party package and `exclude_external_libraries=True` (the default). Pass `exclude_external_libraries=False` to `get_evaluable_architecture()` to include it.
 - **Module never imported**: the module exists but is not imported by any code under the scanned `module_path`, so it was never added to the graph.

--- a/src/pytestarch/eval_structure/exceptions.py
+++ b/src/pytestarch/eval_structure/exceptions.py
@@ -9,7 +9,7 @@ class LayerMismatch(Exception):
     pass
 
 
-class NotInGraph(Exception):
+class ModuleUnknown(Exception):
     """Raised when a queried module is not present in the dependency graph.
 
     The exception message includes actionable guidance on common causes,

--- a/src/pytestarch/eval_structure/exceptions.py
+++ b/src/pytestarch/eval_structure/exceptions.py
@@ -10,4 +10,9 @@ class LayerMismatch(Exception):
 
 
 class NotInGraph(Exception):
-    pass
+    """Raised when a queried module is not present in the dependency graph.
+
+    The exception message includes actionable guidance on common causes,
+    such as the module being an external library that was excluded from the
+    graph or the module name being misspelled.
+    """

--- a/src/pytestarch/eval_structure/exceptions.py
+++ b/src/pytestarch/eval_structure/exceptions.py
@@ -7,3 +7,7 @@ class ImpossibleMatch(Exception):
 
 class LayerMismatch(Exception):
     pass
+
+
+class NotInGraph(Exception):
+    pass

--- a/src/pytestarch/eval_structure/networkxgraph.py
+++ b/src/pytestarch/eval_structure/networkxgraph.py
@@ -10,7 +10,7 @@ import networkx as nx
 from networkx import draw_networkx, has_path, spring_layout
 
 from pytestarch.eval_structure.evaluable_structures import AbstractGraph, AbstractNode
-from pytestarch.eval_structure.exceptions import NotInGraph
+from pytestarch.eval_structure.exceptions import ModuleUnknown
 from pytestarch.eval_structure.types import Import, get_parent_modules
 
 EXPECTED_EDGE_AND_NODE_TYPES = "Only str and tuple of two str supported."
@@ -182,9 +182,9 @@ class NetworkxGraph(AbstractGraph):
             all predecessor nodes
 
         Raises:
-            NotInGraph: if node is not present in the dependency graph
+            ModuleUnknown: if node is not present in the dependency graph
         """
-        self._raise_if_node_missing(node)
+        self._assert_node_exists(node)
         return sorted(self._graph.predecessors(node))
 
     def direct_successor_nodes(self, node: Node) -> list[Node]:
@@ -197,9 +197,9 @@ class NetworkxGraph(AbstractGraph):
             all successor nodes
 
         Raises:
-            NotInGraph: if node is not present in the dependency graph
+            ModuleUnknown: if node is not present in the dependency graph
         """
-        self._raise_if_node_missing(node)
+        self._assert_node_exists(node)
         return sorted(self._graph.successors(node))
 
     def parent_child_relationship(
@@ -304,14 +304,14 @@ class NetworkxGraph(AbstractGraph):
         except StopIteration:  # no alias for module or parent module
             return module_name
 
-    def _raise_if_node_missing(self, node: Node) -> None:
-        """Raises NotInGraph with a diagnostic message if node is absent from the graph.
+    def _assert_node_exists(self, node: Node) -> None:
+        """Raises ModuleUnknown with a diagnostic message if node is absent from the graph.
 
         Args:
             node: the node to check for existence
         """
         if not self._graph.has_node(node):
-            raise NotInGraph(
+            raise ModuleUnknown(
                 f"'{node}' was not found in the dependency graph.\n"
                 "If it is an external library, ensure "
                 "'exclude_external_libraries=False' is passed to "

--- a/src/pytestarch/eval_structure/networkxgraph.py
+++ b/src/pytestarch/eval_structure/networkxgraph.py
@@ -180,6 +180,9 @@ class NetworkxGraph(AbstractGraph):
 
         Returns:
             all predecessor nodes
+
+        Raises:
+            NotInGraph: if node is not present in the dependency graph
         """
         self._raise_if_node_missing(node)
         return sorted(self._graph.predecessors(node))
@@ -192,6 +195,9 @@ class NetworkxGraph(AbstractGraph):
 
         Returns:
             all successor nodes
+
+        Raises:
+            NotInGraph: if node is not present in the dependency graph
         """
         self._raise_if_node_missing(node)
         return sorted(self._graph.successors(node))

--- a/src/pytestarch/eval_structure/networkxgraph.py
+++ b/src/pytestarch/eval_structure/networkxgraph.py
@@ -10,6 +10,7 @@ import networkx as nx
 from networkx import draw_networkx, has_path, spring_layout
 
 from pytestarch.eval_structure.evaluable_structures import AbstractGraph, AbstractNode
+from pytestarch.eval_structure.exceptions import NotInGraph
 from pytestarch.eval_structure.types import Import, get_parent_modules
 
 EXPECTED_EDGE_AND_NODE_TYPES = "Only str and tuple of two str supported."
@@ -180,6 +181,7 @@ class NetworkxGraph(AbstractGraph):
         Returns:
             all predecessor nodes
         """
+        self._raise_if_node_missing(node)
         return sorted(self._graph.predecessors(node))
 
     def direct_successor_nodes(self, node: Node) -> list[Node]:
@@ -191,6 +193,7 @@ class NetworkxGraph(AbstractGraph):
         Returns:
             all successor nodes
         """
+        self._raise_if_node_missing(node)
         return sorted(self._graph.successors(node))
 
     def parent_child_relationship(
@@ -294,6 +297,24 @@ class NetworkxGraph(AbstractGraph):
 
         except StopIteration:  # no alias for module or parent module
             return module_name
+
+    def _raise_if_node_missing(self, node: Node) -> None:
+        """Raises NotInGraph with a diagnostic message if node is absent from the graph.
+
+        Args:
+            node: the node to check for existence
+        """
+        if not self._graph.has_node(node):
+            raise NotInGraph(
+                f"'{node}' was not found in the dependency graph.\n"
+                "If it is an external library, ensure "
+                "'exclude_external_libraries=False' is passed to "
+                "'get_evaluable_architecture()'.\n"
+                "If this flag is already set, the module may not be "
+                "imported by any code in the scanned source path.\n"
+                "Verify the module name is correct as it would appear "
+                "in a Python import statement."
+            )
 
     def _flatten_graph_node(self, node: Node) -> Node:
         """Limits the depth of the graph by aggregating sub modules above a certain limit.

--- a/tests/eval_structure/evaluable_graph/test_module_not_in_graph.py
+++ b/tests/eval_structure/evaluable_graph/test_module_not_in_graph.py
@@ -7,7 +7,7 @@ from pytestarch.eval_structure.evaluable_architecture import (
     ParentModuleNameFilter,
 )
 from pytestarch.eval_structure.evaluable_graph import EvaluableArchitectureGraph
-from pytestarch.eval_structure.exceptions import NotInGraph
+from pytestarch.eval_structure.exceptions import ModuleUnknown
 from pytestarch.eval_structure.networkxgraph import NetworkxGraph
 from pytestarch.eval_structure_generation.file_import.import_types import AbsoluteImport
 
@@ -25,36 +25,36 @@ def graph() -> EvaluableArchitectureGraph:
 def test_direct_successor_nodes_raises_not_in_graph(
     graph: EvaluableArchitectureGraph,
 ) -> None:
-    with pytest.raises(NotInGraph):
+    with pytest.raises(ModuleUnknown):
         graph._graph.direct_successor_nodes(EXTERNAL)
 
 
 def test_direct_predecessor_nodes_raises_not_in_graph(
     graph: EvaluableArchitectureGraph,
 ) -> None:
-    with pytest.raises(NotInGraph):
+    with pytest.raises(ModuleUnknown):
         graph._graph.direct_predecessor_nodes(EXTERNAL)
 
 
 def test_message_names_missing_module(graph: EvaluableArchitectureGraph) -> None:
-    with pytest.raises(NotInGraph, match="'django.db' was not found"):
+    with pytest.raises(ModuleUnknown, match="'django.db' was not found"):
         graph._graph.direct_successor_nodes(EXTERNAL)
 
 
 def test_message_mentions_exclude_flag(graph: EvaluableArchitectureGraph) -> None:
-    with pytest.raises(NotInGraph, match="exclude_external_libraries=False"):
+    with pytest.raises(ModuleUnknown, match="exclude_external_libraries=False"):
         graph._graph.direct_successor_nodes(EXTERNAL)
 
 
 def test_message_mentions_import_statement(graph: EvaluableArchitectureGraph) -> None:
-    with pytest.raises(NotInGraph, match="Python import statement"):
+    with pytest.raises(ModuleUnknown, match="Python import statement"):
         graph._graph.direct_successor_nodes(EXTERNAL)
 
 
 def test_get_dependencies_raises_not_in_graph(
     graph: EvaluableArchitectureGraph,
 ) -> None:
-    with pytest.raises(NotInGraph, match="'django.db' was not found"):
+    with pytest.raises(ModuleUnknown, match="'django.db' was not found"):
         graph.get_dependencies(
             [ModuleNameFilter(name=INTERNAL)],
             [ModuleNameFilter(name=EXTERNAL)],
@@ -64,7 +64,7 @@ def test_get_dependencies_raises_not_in_graph(
 def test_any_other_dependency_raises_not_in_graph(
     graph: EvaluableArchitectureGraph,
 ) -> None:
-    with pytest.raises(NotInGraph, match="'django.db' was not found"):
+    with pytest.raises(ModuleUnknown, match="'django.db' was not found"):
         graph.any_other_dependencies_on_dependent_upons_than_from_dependents(
             [ModuleNameFilter(name=INTERNAL)],
             [ParentModuleNameFilter(parent_module=EXTERNAL)],

--- a/tests/eval_structure/evaluable_graph/test_not_in_graph.py
+++ b/tests/eval_structure/evaluable_graph/test_not_in_graph.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+
+from pytestarch.eval_structure.evaluable_architecture import (
+    ModuleNameFilter,
+    ParentModuleNameFilter,
+)
+from pytestarch.eval_structure.evaluable_graph import EvaluableArchitectureGraph
+from pytestarch.eval_structure.exceptions import NotInGraph
+from pytestarch.eval_structure.networkxgraph import NetworkxGraph
+from pytestarch.eval_structure_generation.file_import.import_types import AbsoluteImport
+
+INTERNAL = "mypackage.service"
+EXTERNAL = "django.db"
+
+
+@pytest.fixture
+def graph() -> EvaluableArchitectureGraph:
+    return EvaluableArchitectureGraph(
+        NetworkxGraph([INTERNAL], [AbsoluteImport(INTERNAL, INTERNAL)])
+    )
+
+
+def test_direct_successor_nodes_raises_not_in_graph(
+    graph: EvaluableArchitectureGraph,
+) -> None:
+    with pytest.raises(NotInGraph):
+        graph._graph.direct_successor_nodes(EXTERNAL)
+
+
+def test_direct_predecessor_nodes_raises_not_in_graph(
+    graph: EvaluableArchitectureGraph,
+) -> None:
+    with pytest.raises(NotInGraph):
+        graph._graph.direct_predecessor_nodes(EXTERNAL)
+
+
+def test_message_names_missing_module(graph: EvaluableArchitectureGraph) -> None:
+    with pytest.raises(NotInGraph, match="'django.db' was not found"):
+        graph._graph.direct_successor_nodes(EXTERNAL)
+
+
+def test_message_mentions_exclude_flag(graph: EvaluableArchitectureGraph) -> None:
+    with pytest.raises(NotInGraph, match="exclude_external_libraries=False"):
+        graph._graph.direct_successor_nodes(EXTERNAL)
+
+
+def test_message_mentions_import_statement(graph: EvaluableArchitectureGraph) -> None:
+    with pytest.raises(NotInGraph, match="Python import statement"):
+        graph._graph.direct_successor_nodes(EXTERNAL)
+
+
+def test_get_dependencies_raises_not_in_graph(
+    graph: EvaluableArchitectureGraph,
+) -> None:
+    with pytest.raises(NotInGraph, match="'django.db' was not found"):
+        graph.get_dependencies(
+            [ModuleNameFilter(name=INTERNAL)],
+            [ModuleNameFilter(name=EXTERNAL)],
+        )
+
+
+def test_any_other_dependency_raises_not_in_graph(
+    graph: EvaluableArchitectureGraph,
+) -> None:
+    with pytest.raises(NotInGraph, match="'django.db' was not found"):
+        graph.any_other_dependencies_on_dependent_upons_than_from_dependents(
+            [ModuleNameFilter(name=INTERNAL)],
+            [ParentModuleNameFilter(parent_module=EXTERNAL)],
+        )


### PR DESCRIPTION
For addressing #132 

Add a new `NotInGraph` exception to `exceptions.py` and modify `direct_successor_nodes` and `direct_predecessor_nodes` in `NetworkxGraph` to check node existence before calling NetworkX, raising `NotInGraph` with a helpful message that:
1. Names the missing module
2. Hints about `exclude_external_libraries=False` if the module might be external
3. Suggests checking the module name spelling
4. Suggests checking whether the module is actually imported anywhere

Probably too verbose but the machinery is there.