### PR TITLE
fix: Read code as bytes to avoid win utf-8 issue

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ This project uses semantic versioning and follows [keep a changelog](https://kee
 - Typo in docstring of `get_evaluable_architecture(..)`.
 - Module filter uses regex when activated instead of only if last module.
 - Descriptive error message with actionable guidance when a queried module is not present in the dependency graph.
+- Parser no longer errors out on windows due to unspecified encoding.
 
 ## 4.0.1 -- 2025-08-08
 ### Fixed

--- a/src/pytestarch/eval_structure_generation/file_import/parser.py
+++ b/src/pytestarch/eval_structure_generation/file_import/parser.py
@@ -51,8 +51,7 @@ class Parser:
         """Converts a given python file to an ast module and its name."""
         absolute_path = path.resolve()
         if self._file_should_be_parsed(absolute_path):
-            with open(absolute_path) as file:
-                code = file.read()
+            code = absolute_path.read_bytes()
 
             module_name = self._get_module_name(path)
             self._all_modules.append(module_name)

--- a/tests/eval_structure_generation/test_parser.py
+++ b/tests/eval_structure_generation/test_parser.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 from pytestarch.eval_structure_generation.file_import.config import Config
 from pytestarch.eval_structure_generation.file_import.file_filter import FileFilter
@@ -42,3 +47,49 @@ def test_parser_parses_all_files_in_directory() -> None:
     }
 
     assert set(map(lambda module: module.name, parsed_modules)) == expected_modules
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "print('content')",
+        "print('「content」😭')",
+    ],
+)
+def test_parser_reads_special_chars(tmp_path, contents) -> None:
+    """
+    Tests that parser handles special chars in the file it parses.
+    """
+    code_file = tmp_path / "code.py"
+    code_file.write_text(contents)
+    result: subprocess.CompletedProcess = subprocess.run(  # noqa:S603 // Input is entirely controlled by test.
+        [
+            sys.executable,
+            "-c",
+            f"""
+from pytestarch.eval_structure_generation import file_import as fi
+from pytestarch.utils.partial_match_to_regex_converter import (
+    convert_partial_match_to_regex,
+)
+from pathlib import Path
+fi.parser.Parser(
+    fi.file_filter.FileFilter(fi.config.Config((convert_partial_match_to_regex("*__pycache__"),))),
+    Path("{tmp_path!s}")
+).parse(Path("{tmp_path!s}"))
+            """,
+        ],
+        env={
+            **os.environ,
+            **{
+                "LC_ALL": "C",
+                "PYTHONUTF8": "0",
+                "LANG": "C",
+                "PYTHONCOERCELOCALE": "0",
+            },
+        },
+        capture_output=True,
+    )
+
+    assert "UnicodeDecodeError" not in result.stderr.decode("utf-8"), (
+        "Parser fails to parse code files with utf-8 character contents."
+    )


### PR DESCRIPTION
On windows PyTestArch crashes at file read in because it attempts to read in the code with no encoding specified. Windows can default to an encoding which does not support UTF-8 which means Unicode characters can cause this operation to fail. The text is actually unused in this location so we can instead sidestep this issue by reading in bytes.

---

On testing side, as this requires python to be started with no utf-8 support, I've implemented it as a subprocess python call to the parser with envvars set to trigger the failing case. 

---

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT [https://www.apache.org/licenses/LICENSE-2.0](https://www.apache.org/licenses/LICENSE-2.0).

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.